### PR TITLE
add kubernetes job for functional tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,6 @@ COPY gradlew /opt/functional-tests/gradlew
 
 WORKDIR /opt/functional-tests
 
+RUN ./gradlew compileTestKotlin
+
 CMD ["./gradlew", "cleanTest", "test", "-i", "-Djunit.jupiter.extensions.autodetection.enabled=true"]

--- a/_infra/kubernetes/job.yaml
+++ b/_infra/kubernetes/job.yaml
@@ -1,0 +1,12 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: functional-test
+spec:
+  template:
+    spec:
+      containers:
+      - name: functional-test
+        image: eu.gcr.io/sbat-gcr-develop/securebanking/functional-tests:latest
+      restartPolicy: Never
+  backoffLimit: 0


### PR DESCRIPTION
Add a kubernetes manifest for deploying the functional tests into kubernetes and ensure that the compile target is executed at the `RUN` docker phase.

issue: https://github.com/SecureBankingAccessToolkit/sbat-cd/issues/7