### PR TITLE
240: AISP evaluation policy for party api

### DIFF
--- a/src/test/kotlin/com/forgerock/securebanking/support/account/AccountRS.kt
+++ b/src/test/kotlin/com/forgerock/securebanking/support/account/AccountRS.kt
@@ -106,15 +106,13 @@ class AccountRS {
 
     inline fun <reified T : Any> getAccountsDataEndUser(
         accountDataUrl: String,
-        accessToken: AccessToken,
-        psu: UserRegistrationRequest
+        accessToken: AccessToken
     ): T {
         val xObURL = "$IG_SERVER/${accountDataUrl.substring(accountDataUrl.indexOf("rs/") + 3)}"
         val (_, accountResult, r) = Fuel.get(accountDataUrl)
             .header("Authorization", "Bearer ${accessToken.access_token}")
             .header("x-fapi-financial-id", rsDiscovery.Data.FinancialId ?: "")
             .header("x-ob-url", xObURL)
-            .header("x-ob-user-id", psu.user.uid ?: "")
             .responseObject<T>()
         if (!accountResult.isSuccessful) throw AssertionError(
             "Could not get requested account data from ${accountDataUrl}: ${

--- a/src/test/kotlin/com/forgerock/securebanking/tests/functional/account/parties/GetAccountPartiesTest.kt
+++ b/src/test/kotlin/com/forgerock/securebanking/tests/functional/account/parties/GetAccountPartiesTest.kt
@@ -92,7 +92,7 @@ class GetAccountPartiesTest(val tppResource: CreateTppCallback.TppResource) {
             urlWithAccountId(
                 accountAndTransaction3_1_8.Links.links.GetAccountParties,
                 accountId
-            ), accessToken, psu
+            ), accessToken
         )
 
         // Then

--- a/src/test/kotlin/com/forgerock/securebanking/tests/functional/account/parties/GetAccountPartyTest.kt
+++ b/src/test/kotlin/com/forgerock/securebanking/tests/functional/account/parties/GetAccountPartyTest.kt
@@ -58,7 +58,7 @@ class GetAccountPartyTest(val tppResource: CreateTppCallback.TppResource) {
             urlWithAccountId(
                 accountAndTransaction3_1.Links.links.GetAccountParty,
                 accountId
-            ), accessToken, psu
+            ), accessToken
         )
 
         // Then
@@ -153,7 +153,7 @@ class GetAccountPartyTest(val tppResource: CreateTppCallback.TppResource) {
             urlWithAccountId(
                 accountAndTransaction3_1_8.Links.links.GetAccountParty,
                 accountId
-            ), accessToken, psu
+            ), accessToken
         )
 
         // Then

--- a/src/test/kotlin/com/forgerock/securebanking/tests/functional/account/parties/GetPartyTest.kt
+++ b/src/test/kotlin/com/forgerock/securebanking/tests/functional/account/parties/GetPartyTest.kt
@@ -55,8 +55,7 @@ class GetPartyTest(val tppResource: CreateTppCallback.TppResource) {
         val party =
             AccountRS().getAccountsDataEndUser<OBReadParty1>(
                 accountAndTransaction3_1.Links.links.GetParty,
-                accessToken,
-                psu
+                accessToken
             )
 
         // Then
@@ -144,8 +143,7 @@ class GetPartyTest(val tppResource: CreateTppCallback.TppResource) {
         val party =
             AccountRS().getAccountsDataEndUser<OBReadParty2>(
                 accountAndTransaction3_1_8.Links.links.GetParty,
-                accessToken,
-                psu
+                accessToken
             )
 
         // Then


### PR DESCRIPTION
- Deleted the userid for party tests
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/240