### PR TITLE
333: Create functional tests coverage for domestic standing order consent

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -261,6 +261,15 @@ tasks.register<Test>("domestic_scheduled_payments_$apiVersion") {
     failFast = false
 }
 
+tasks.register<Test>("domestic_standing_order_$apiVersion") {
+    group = "payments-tests"
+    description = "Runs the payments tests with the version $apiVersion"
+    filter {
+        includeTestsMatching(packagePrefix + "payment.domestic.standing.order" + suffixPattern + apiVersion)
+    }
+    failFast = false
+}
+
 /* ALL IMPLEMENTED TESTS */
 tasks.register<Test>("tests_$apiVersion") {
     group = "tests"
@@ -269,6 +278,7 @@ tasks.register<Test>("tests_$apiVersion") {
         includeTestsMatching(packagePrefix + "account" + suffixPattern + apiVersion)
         includeTestsMatching(packagePrefix + "payment.domestic.payments" + suffixPattern + apiVersion)
         includeTestsMatching(packagePrefix + "payment.domestic.scheduled.payments" + suffixPattern + apiVersion)
+        includeTestsMatching(packagePrefix + "payment.domestic.standing.order" + suffixPattern + apiVersion)
     }
     failFast = false
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/framework/constants/Constants.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/framework/constants/Constants.kt
@@ -1,5 +1,7 @@
 package com.forgerock.uk.openbanking.framework.constants
 
 const val REDIRECT_URI = "https://google.com"
+const val INVALID_FREQUENCY = "EvryDay:02:03"
+
 
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/framework/errors/Errors.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/framework/errors/Errors.kt
@@ -8,3 +8,5 @@ const val PAYMENT_SUBMISSION_ALREADY_EXISTS = "Payment submission already exists
 const val B64_HEADER_NOT_PERMITTED = "B64 header not permitted in JWT header after v3.1.3"
 const val UNAUTHORIZED = "Unauthorized"
 const val INVALID_DETACHED_JWS_ERROR = "Could not validate detached JWS -"
+const val INVALID_FREQUENCY_VALUE = "Invalid frequency value in the request payload."
+

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentRS.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentRS.kt
@@ -104,7 +104,7 @@ class PaymentRS {
             .header("x-fapi-financial-id", rsDiscovery.Data.FinancialId ?: "")
             .responseObject<T>()
         if (!consentResponse.isSuccessful) throw AssertionError(
-            "Could not create the consent: \n" + result.component2()?.errorData?.toString(Charsets.UTF_8),
+            "Could not get the consent: \n" + result.component2()?.errorData?.toString(Charsets.UTF_8),
             result.component2()
         )
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/CreateDomesticStandingOrderConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/CreateDomesticStandingOrderConsentsTest.kt
@@ -1,0 +1,1284 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.consents
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEmpty
+import assertk.assertions.isNotNull
+import com.forgerock.securebanking.framework.conditions.Status
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.framework.http.fuel.defaultMapper
+import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
+import com.forgerock.securebanking.framework.signature.signPayloadSubmitPaymentInvalidB64ClaimTrue
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.framework.constants.INVALID_FORMAT_DETACHED_JWS
+import com.forgerock.uk.openbanking.framework.constants.INVALID_FREQUENCY
+import com.forgerock.uk.openbanking.framework.constants.INVALID_SIGNING_KID
+import com.forgerock.uk.openbanking.framework.errors.*
+import com.forgerock.uk.openbanking.support.discovery.*
+import com.forgerock.uk.openbanking.support.payment.PaymentRS
+import com.github.kittinunf.fuel.core.FuelError
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsentTestDataFactory.*
+
+class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createDomesticStandingOrdersConsents_v3_1_8() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent5()
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid
+            )
+
+        // When
+        val consent = PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse6>(
+            payment3_1_8.Links.links.CreateDomesticStandingOrderConsent,
+            consentRequest,
+            tppResource.tpp,
+            OBVersion.v3_1_8,
+            signedPayloadConsent
+        )
+
+        // Then
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consent.risk).isNotNull()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createDomesticStandingOrdersConsents_mandatoryFields_v3_1_8() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent5MandatoryFields()
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid
+            )
+
+        // When
+        val consent = PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse6>(
+            payment3_1_8.Links.links.CreateDomesticStandingOrderConsent,
+            consentRequest,
+            tppResource.tpp,
+            OBVersion.v3_1_8,
+            signedPayloadConsent
+        )
+
+        // Then
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consent.risk).isNotNull()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsInvalidFrequencyValue_v3_1_8() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent5()
+        consentRequest.data.initiation.frequency =  INVALID_FREQUENCY
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid
+            )
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse6>(
+                payment3_1_8.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_8,
+                signedPayloadConsent
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(INVALID_FREQUENCY_VALUE)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidFormatDetachedJws_v3_1_8() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent5()
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse6>(
+                payment3_1_8.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_8,
+                INVALID_FORMAT_DETACHED_JWS
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(INVALID_FORMAT_DETACHED_JWS_ERROR)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsNoDetachedJws_v3_1_8() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent5()
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consentNoDetachedJwt<OBWriteDomesticStandingOrderConsentResponse6>(
+                payment3_1_8.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_8
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(NO_DETACHED_JWS)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_8() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent5()
+
+        val signedPayload =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid,
+                true
+            )
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse6>(
+                payment3_1_8.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_8,
+                signedPayload
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidKidDetachedJws_v3_1_8() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent5()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                INVALID_SIGNING_KID
+            )
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse6>(
+                payment3_1_8.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_8,
+                signedPayloadConsent
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.4",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun createDomesticStandingOrdersConsents_v3_1_4() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent5()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid
+            )
+
+        // When
+        val consent = PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse5>(
+            payment3_1_4.Links.links.CreateDomesticStandingOrderConsent,
+            consentRequest,
+            tppResource.tpp,
+            OBVersion.v3_1_4,
+            signedPayloadConsent
+        )
+
+        // Then
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consent.risk).isNotNull()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.4",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun createDomesticStandingOrdersConsents_mandatoryFields_v3_1_4() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent5MandatoryFields()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid
+            )
+
+        // When
+        val consent = PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse5>(
+            payment3_1_4.Links.links.CreateDomesticStandingOrderConsent,
+            consentRequest,
+            tppResource.tpp,
+            OBVersion.v3_1_4,
+            signedPayloadConsent
+        )
+
+        // Then
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consent.risk).isNotNull()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.4",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsInvalidFrequencyValue_v3_1_4() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent5()
+        consentRequest.data.initiation.frequency =  INVALID_FREQUENCY
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid
+            )
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse5>(
+                payment3_1_4.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_4,
+                signedPayloadConsent
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(INVALID_FREQUENCY_VALUE)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.4",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidFormatDetachedJws_v3_1_4() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent5()
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse5>(
+                payment3_1_4.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_4,
+                INVALID_FORMAT_DETACHED_JWS
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(INVALID_FORMAT_DETACHED_JWS_ERROR)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.4",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsNoDetachedJws_v3_1_4() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent5()
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consentNoDetachedJwt<OBWriteDomesticStandingOrderConsentResponse5>(
+                payment3_1_4.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_4
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(NO_DETACHED_JWS)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.4",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_4() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent5()
+        val signedPayload =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid,
+                true
+            )
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse5>(
+                payment3_1_4.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_4,
+                signedPayload
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.4",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidKidDetachedJws_v3_1_4() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent5()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                INVALID_SIGNING_KID
+            )
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse5>(
+                payment3_1_4.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_4,
+                signedPayloadConsent
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(SIGNATURE_VALIDATION_FAILED)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.3",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.2"]
+    )
+    @Test
+    fun createDomesticStandingOrdersConsents_v3_1_3() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid,
+                true
+            )
+
+        // When
+        val consent = PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse4>(
+            payment3_1_3.Links.links.CreateDomesticStandingOrderConsent,
+            consentRequest,
+            tppResource.tpp,
+            OBVersion.v3_1_3,
+            signedPayloadConsent
+        )
+
+        // Then
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consent.risk).isNotNull()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.3",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.2"]
+    )
+    @Test
+    fun createDomesticStandingOrdersConsents_mandatoryFields_v3_1_3() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent4MandatoryFields()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid,
+                true
+            )
+
+        // When
+        val consent = PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse4>(
+            payment3_1_3.Links.links.CreateDomesticStandingOrderConsent,
+            consentRequest,
+            tppResource.tpp,
+            OBVersion.v3_1_3,
+            signedPayloadConsent
+        )
+
+        // Then
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consent.risk).isNotNull()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.3",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.2"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsInvalidFrequencyValue_v3_1_3() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
+        consentRequest.data.initiation.frequency =  INVALID_FREQUENCY
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid,
+                true
+            )
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse4>(
+                payment3_1_3.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_3,
+                signedPayloadConsent
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(INVALID_FREQUENCY_VALUE)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.3",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.2"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidFormatDetachedJws_v3_1_3() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse4>(
+                payment3_1_3.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_3,
+                INVALID_FORMAT_DETACHED_JWS
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(INVALID_FORMAT_DETACHED_JWS_ERROR)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.3",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.2"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsNoDetachedJws_v3_1_3() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consentNoDetachedJwt<OBWriteDomesticStandingOrderConsentResponse4>(
+                payment3_1_3.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_3
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(NO_DETACHED_JWS)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.3",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.2"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidKidDetachedJws_v3_1_3() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                INVALID_SIGNING_KID,
+                true
+            )
+
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse4>(
+                payment3_1_3.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_3,
+                signedPayloadConsent
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(SIGNATURE_VALIDATION_FAILED)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.3",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.2"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsB64ClaimMissingDetachedJws_v3_1_3() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid
+            )
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse4>(
+                payment3_1_3.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_3,
+                signedPayloadConsent
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.3",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.2"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsB64ClaimShouldBeFalseDetachedJws_v3_1_3() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPaymentInvalidB64ClaimTrue(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid
+            )
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse4>(
+                payment3_1_3.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_3,
+                signedPayloadConsent
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.1",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun createDomesticStandingOrdersConsents_v3_1_1() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid,
+                true
+            )
+
+        // When
+        val consent = PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse3>(
+            payment3_1_1.Links.links.CreateDomesticStandingOrderConsent,
+            consentRequest,
+            tppResource.tpp,
+            OBVersion.v3_1_1,
+            signedPayloadConsent
+        )
+
+        // Then
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consent.risk).isNotNull()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.1",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun createDomesticStandingOrdersConsents_mandatoryFields_v3_1_1() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent3MandatoryFields()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid,
+                true
+            )
+
+        // When
+        val consent = PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse3>(
+            payment3_1_1.Links.links.CreateDomesticStandingOrderConsent,
+            consentRequest,
+            tppResource.tpp,
+            OBVersion.v3_1_1,
+            signedPayloadConsent
+        )
+
+        // Then
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consent.risk).isNotNull()
+    }
+
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.1",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsInvalidFrequencyValue_v3_1_1() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
+        consentRequest.data.initiation.frequency =  INVALID_FREQUENCY
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid,
+                true
+            )
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse3>(
+                payment3_1_1.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_1,
+                signedPayloadConsent
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(INVALID_FREQUENCY_VALUE)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.1",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidFormatDetachedJws_v3_1_1() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse3>(
+                payment3_1_1.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_1,
+                INVALID_FORMAT_DETACHED_JWS
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(INVALID_FORMAT_DETACHED_JWS_ERROR)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.1",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsNoDetachedJws_v3_1_1() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consentNoDetachedJwt<OBWriteDomesticStandingOrderConsentResponse3>(
+                payment3_1_1.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_1
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(NO_DETACHED_JWS)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.1",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidKidDetachedJws_v3_1_1() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                INVALID_SIGNING_KID,
+                true
+            )
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse3>(
+                payment3_1_1.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_1,
+                signedPayloadConsent
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(SIGNATURE_VALIDATION_FAILED)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.1",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsB64ClaimMissingDetachedJws_v3_1_1() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid
+            )
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse3>(
+                payment3_1_1.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_1,
+                signedPayloadConsent
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.1",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsB64ClaimShouldBeFalseDetachedJws_v3_1_1() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPaymentInvalidB64ClaimTrue(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid
+            )
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse3>(
+                payment3_1_1.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_1,
+                signedPayloadConsent
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun createDomesticStandingOrdersConsents_v3_1() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid,
+                true
+            )
+
+        // When
+        val consent = PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse2>(
+            payment3_1.Links.links.CreateDomesticStandingOrderConsent,
+            consentRequest,
+            tppResource.tpp,
+            OBVersion.v3_1,
+            signedPayloadConsent
+        )
+
+        // Then
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consent.risk).isNotNull()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun createDomesticStandingOrdersConsents_mandatoryFields_v3_1() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent2MandatoryFields()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid,
+                true
+            )
+
+        // When
+        val consent = PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse2>(
+            payment3_1.Links.links.CreateDomesticStandingOrderConsent,
+            consentRequest,
+            tppResource.tpp,
+            OBVersion.v3_1,
+            signedPayloadConsent
+        )
+
+        // Then
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consent.risk).isNotNull()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsInvalidFrequencyValue_v3_1() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()
+        consentRequest.data.initiation.frequency =  INVALID_FREQUENCY
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid,
+                true
+            )
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse2>(
+                payment3_1.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1,
+                signedPayloadConsent
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(INVALID_FREQUENCY_VALUE)
+    }
+
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidFormatDetachedJws_v3_1() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse2>(
+                payment3_1.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1,
+                INVALID_FORMAT_DETACHED_JWS
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(INVALID_FORMAT_DETACHED_JWS_ERROR)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsNoDetachedJws_v3_1() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consentNoDetachedJwt<OBWriteDomesticStandingOrderConsentResponse2>(
+                payment3_1.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(NO_DETACHED_JWS)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidKidDetachedJws_v3_1() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                INVALID_SIGNING_KID,
+                true
+            )
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse2>(
+                payment3_1.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1,
+                signedPayloadConsent
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(SIGNATURE_VALIDATION_FAILED)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsB64ClaimMissingDetachedJws_v3_1() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid
+            )
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse2>(
+                payment3_1.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1,
+                signedPayloadConsent
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsB64ClaimShouldBeFalseDetachedJws_v3_1() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPaymentInvalidB64ClaimTrue(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid
+            )
+
+        // When
+        val exception = assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse2>(
+                payment3_1.Links.links.CreateDomesticStandingOrderConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1,
+                signedPayloadConsent
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/GetDomesticStandingOrderConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/GetDomesticStandingOrderConsentsTest.kt
@@ -1,0 +1,284 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.consents
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEmpty
+import assertk.assertions.isNotNull
+import com.forgerock.securebanking.framework.conditions.Status
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.framework.http.fuel.defaultMapper
+import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
+import com.forgerock.securebanking.framework.signature.signPayloadSubmitPaymentInvalidB64ClaimTrue
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.framework.constants.INVALID_FORMAT_DETACHED_JWS
+import com.forgerock.uk.openbanking.framework.constants.INVALID_FREQUENCY
+import com.forgerock.uk.openbanking.framework.constants.INVALID_SIGNING_KID
+import com.forgerock.uk.openbanking.framework.errors.*
+import com.forgerock.uk.openbanking.support.discovery.*
+import com.forgerock.uk.openbanking.support.payment.PaymentFactory
+import com.forgerock.uk.openbanking.support.payment.PaymentRS
+import com.github.kittinunf.fuel.core.FuelError
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsentTestDataFactory.*
+
+class GetDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetDomesticStandingOrdersConsents_v3_1_8() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent5()
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid
+            )
+
+        val consent = PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse6>(
+            payment3_1_8.Links.links.CreateDomesticStandingOrderConsent,
+            consentRequest,
+            tppResource.tpp,
+            OBVersion.v3_1_8,
+            signedPayloadConsent
+        )
+
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consent.risk).isNotNull()
+
+        // When
+        val result = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
+            PaymentFactory.urlWithConsentId(
+                payment3_1_8.Links.links.GetDomesticStandingOrderConsent,
+                consent.data.consentId
+            ),
+            tppResource.tpp,
+            OBVersion.v3_1_8
+        )
+
+        // Then
+        assertThat(result).isNotNull()
+        assertThat(result.data).isNotNull()
+        assertThat(result.risk).isNotNull()
+        assertThat(result.data).isEqualTo(consent.data)
+        assertThat(result.risk).isEqualTo(consent.risk)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.4",
+        operations = ["CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldGetDomesticStandingOrdersConsents_v3_1_4() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent5()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid
+            )
+
+
+        val consent = PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse5>(
+            payment3_1_4.Links.links.CreateDomesticStandingOrderConsent,
+            consentRequest,
+            tppResource.tpp,
+            OBVersion.v3_1_4,
+            signedPayloadConsent
+        )
+
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consent.risk).isNotNull()
+
+        // When
+        val result = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse5>(
+            PaymentFactory.urlWithConsentId(
+                payment3_1_4.Links.links.GetDomesticStandingOrderConsent,
+                consent.data.consentId
+            ),
+            tppResource.tpp,
+            OBVersion.v3_1_4
+        )
+
+        // Then
+        assertThat(result).isNotNull()
+        assertThat(result.data).isNotNull()
+        assertThat(result.risk).isNotNull()
+        assertThat(result.data).isEqualTo(consent.data)
+        assertThat(result.risk).isEqualTo(consent.risk)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.3",
+        operations = ["CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.2"]
+    )
+    @Test
+    fun shouldGetDomesticStandingOrdersConsents_v3_1_3() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid,
+                true
+            )
+
+        val consent = PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse4>(
+            payment3_1_3.Links.links.CreateDomesticStandingOrderConsent,
+            consentRequest,
+            tppResource.tpp,
+            OBVersion.v3_1_3,
+            signedPayloadConsent
+        )
+
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consent.risk).isNotNull()
+
+        // When
+        val result = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse4>(
+            PaymentFactory.urlWithConsentId(
+                payment3_1_3.Links.links.GetDomesticStandingOrderConsent,
+                consent.data.consentId
+            ),
+            tppResource.tpp,
+            OBVersion.v3_1_3
+        )
+
+        // Then
+        assertThat(result).isNotNull()
+        assertThat(result.data).isNotNull()
+        assertThat(result.risk).isNotNull()
+        assertThat(result.data).isEqualTo(consent.data)
+        assertThat(result.risk).isEqualTo(consent.risk)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.1",
+        operations = ["CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldGetDomesticStandingOrdersConsents_v3_1_1() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid,
+                true
+            )
+
+        val consent = PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse3>(
+            payment3_1_1.Links.links.CreateDomesticStandingOrderConsent,
+            consentRequest,
+            tppResource.tpp,
+            OBVersion.v3_1_1,
+            signedPayloadConsent
+        )
+
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consent.risk).isNotNull()
+
+        // When
+        val result = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse3>(
+            PaymentFactory.urlWithConsentId(
+                payment3_1_1.Links.links.GetDomesticStandingOrderConsent,
+                consent.data.consentId
+            ),
+            tppResource.tpp,
+            OBVersion.v3_1_1
+        )
+
+        // Then
+        assertThat(result).isNotNull()
+        assertThat(result.data).isNotNull()
+        assertThat(result.risk).isNotNull()
+        assertThat(result.data).isEqualTo(consent.data)
+        assertThat(result.risk).isEqualTo(consent.risk)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1",
+        operations = ["CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldGetDomesticStandingOrdersConsents_v3_1() {
+        // Given
+        val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid,
+                true
+            )
+
+        val consent = PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse2>(
+            payment3_1.Links.links.CreateDomesticStandingOrderConsent,
+            consentRequest,
+            tppResource.tpp,
+            OBVersion.v3_1,
+            signedPayloadConsent
+        )
+
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consent.risk).isNotNull()
+
+        // When
+        val result = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse2>(
+            PaymentFactory.urlWithConsentId(
+                payment3_1.Links.links.GetDomesticStandingOrderConsent,
+                consent.data.consentId
+            ),
+            tppResource.tpp,
+            OBVersion.v3_1
+        )
+
+        // Then
+        assertThat(result).isNotNull()
+        assertThat(result.data).isNotNull()
+        assertThat(result.risk).isNotNull()
+        assertThat(result.data).isEqualTo(consent.data)
+        assertThat(result.risk).isEqualTo(consent.risk)
+    }
+}


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/333