### PR TITLE
237: sharedAccounts field to accountIds direct mapping

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -265,11 +265,11 @@ tasks.register<Test>("domestic_scheduled_payments_$apiVersion") {
 tasks.register<Test>("tests_$apiVersion") {
     group = "tests"
     description = "Runs the tests with the version $apiVersion"
-    dependsOn(
-        "accounts_$apiVersion",
-        "domestic_payments_$apiVersion",
-        "domestic_scheduled_payments_$apiVersion"
-    )
+    filter {
+        includeTestsMatching(packagePrefix + "account" + suffixPattern + apiVersion)
+        includeTestsMatching(packagePrefix + "payment.domestic.payments" + suffixPattern + apiVersion)
+        includeTestsMatching(packagePrefix + "payment.domestic.scheduled.payments" + suffixPattern + apiVersion)
+    }
     failFast = false
 }
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/account/AccountAS.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/account/AccountAS.kt
@@ -28,7 +28,7 @@ class AccountAS : GeneralAS() {
     data class SendConsentDecisionRequestBody(
         val consentJwt: String,
         val decision: String,
-        val sharedAccounts: List<String>
+        val accountIds: List<String>
     )
 
     fun getAccessToken(


### PR DESCRIPTION
- Fix the field to submit the consent decision
- Fix tests_$VERSION, rollback dependsOn to use filter{}
Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/237