### PR TITLE
440: Refactoring functional tests to support reusing test logic across multiple versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("javax.xml.bind:jaxb-api:2.3.1")
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
-    implementation(platform("com.forgerock.securebanking.uk:securebanking-openbanking-uk-bom:1.1.3-SNAPSHOT"))
+    implementation(platform("com.forgerock.securebanking.uk:securebanking-openbanking-uk-bom:1.1.4-SNAPSHOT"))
     implementation("com.forgerock.securebanking.uk:securebanking-openbanking-uk-common")
     implementation("com.forgerock.securebanking.uk:securebanking-openbanking-uk-obie-datamodel")
     implementation("com.forgerock.securebanking.uk:securebanking-openbanking-uk-forgerock-datamodel")

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/discovery/RsDiscovery.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/discovery/RsDiscovery.kt
@@ -1,6 +1,7 @@
 package com.forgerock.uk.openbanking.support.discovery
 
 import com.forgerock.securebanking.framework.configuration.IG_SERVER
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.isSuccessful
 import com.github.kittinunf.fuel.gson.gsonDeserializer
@@ -180,6 +181,36 @@ val rsDiscoveryMap by lazy {
         "funds" to funds,
         "events" to events
     )
+}
+
+// Maps apiName -> version -> links
+val rsDiscoveryApiToVersionLinks by lazy {
+    val paymentVersions = rsDiscovery.Data.PaymentInitiationAPI?.map { it.Version to it.Links.links }?.toMap()
+    val accounts = rsDiscovery.Data.AccountAndTransactionAPI?.map { it.Version to it.Links.links }?.toMap()
+    val funds = rsDiscovery.Data.FundsConfirmationAPI?.map { it.Version to it.Links.links }?.toMap()
+    val events = rsDiscovery.Data.EventNotificationAPI?.map { it.Version to it.Links.links }?.toMap()
+    return@lazy mapOf(
+        "payments" to paymentVersions,
+        "accounts" to accounts,
+        "funds" to funds,
+        "events" to events
+    )
+}
+
+fun getAccountsApiLinks(version: OBVersion): RsDiscovery.RsDiscoveryData.RsDiscoveryAccountAndTransactionAPI.RsDiscoveryAccountAndTransactionAPILinks.Links {
+    return rsDiscoveryApiToVersionLinks["accounts"]?.get(version.canonicalName) as RsDiscovery.RsDiscoveryData.RsDiscoveryAccountAndTransactionAPI.RsDiscoveryAccountAndTransactionAPILinks.Links
+}
+
+fun getPaymentsApiLinks(version: OBVersion): RsDiscovery.RsDiscoveryData.RsDiscoveryPaymentInitiationAPI.RsDiscoveryPaymentInitiationAPILinks.Links {
+    return rsDiscoveryApiToVersionLinks["payments"]?.get(version.canonicalName) as RsDiscovery.RsDiscoveryData.RsDiscoveryPaymentInitiationAPI.RsDiscoveryPaymentInitiationAPILinks.Links
+}
+
+fun getFundsApiLinks(version: OBVersion): RsDiscovery.RsDiscoveryData.RsDiscoveryFundsConfirmationAPI.RsDiscoveryFundsConfirmationAPILinks.Links {
+    return rsDiscoveryApiToVersionLinks["funds"]?.get(version.canonicalName) as RsDiscovery.RsDiscoveryData.RsDiscoveryFundsConfirmationAPI.RsDiscoveryFundsConfirmationAPILinks.Links
+}
+
+fun getEventsApiLinks(version: OBVersion): RsDiscovery.RsDiscoveryData.RsDiscoveryEventNotificationAPI.RsDiscoveryEventNotificationAPILinks.Links {
+    return rsDiscoveryApiToVersionLinks["events"]?.get(version.canonicalName) as RsDiscovery.RsDiscoveryData.RsDiscoveryEventNotificationAPI.RsDiscoveryEventNotificationAPILinks.Links
 }
 
 /**

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/balances/GetAccountBalancesTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/balances/GetAccountBalancesTest.kt
@@ -6,17 +6,52 @@ import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.configuration.psu
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.support.account.AccountAS
 import com.forgerock.uk.openbanking.support.account.AccountFactory.Companion.urlWithAccountId
 import com.forgerock.uk.openbanking.support.account.AccountRS
-import com.forgerock.uk.openbanking.support.discovery.accountAndTransaction3_1_2
-import com.forgerock.uk.openbanking.support.discovery.accountAndTransaction3_1_8
+import com.forgerock.uk.openbanking.support.discovery.getAccountsApiLinks
 import org.junit.jupiter.api.Test
 import uk.org.openbanking.datamodel.account.*
 import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code.READACCOUNTSDETAIL
 import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code.READBALANCES
 
 class GetAccountBalancesTest(val tppResource: CreateTppCallback.TppResource) {
+
+    private fun shouldGetBalances(version: OBVersion) {
+        val accountsApiLinks = getAccountsApiLinks(version)
+
+        // Given
+        val consentRequest = OBReadConsent1().data(
+            OBReadData1()
+                .permissions(listOf(READACCOUNTSDETAIL, READBALANCES))
+        )
+            .risk(OBRisk2())
+        val consent = AccountRS().consent<OBReadConsentResponse1>(
+            accountsApiLinks.CreateAccountAccessConsent,
+            consentRequest,
+            tppResource.tpp
+        )
+        val accessToken = AccountAS().getAccessToken(
+            consent.data.consentId,
+            tppResource.tpp.registrationResponse,
+            psu,
+            tppResource.tpp
+        )
+        val accountId = AccountRS().getFirstAccountId(accountsApiLinks.GetAccounts, accessToken)
+
+        // When
+        val result = AccountRS().getAccountsData<OBReadBalance1>(
+            urlWithAccountId(
+                accountsApiLinks.GetAccountBalances,
+                accountId
+            ), accessToken
+        )
+
+        // Then
+        assertThat(result).isNotNull()
+        assertThat(result.data.balance).isNotEmpty()
+    }
 
     @EnabledIfVersion(
         type = "accounts",
@@ -27,36 +62,7 @@ class GetAccountBalancesTest(val tppResource: CreateTppCallback.TppResource) {
     )
     @Test
     fun shouldGetBalances_v3_1_2() {
-        // Given
-        val consentRequest = OBReadConsent1().data(
-            OBReadData1()
-                .permissions(listOf(READACCOUNTSDETAIL, READBALANCES))
-        )
-            .risk(OBRisk2())
-        val consent = AccountRS().consent<OBReadConsentResponse1>(
-            accountAndTransaction3_1_2.Links.links.CreateAccountAccessConsent,
-            consentRequest,
-            tppResource.tpp
-        )
-        val accessToken = AccountAS().getAccessToken(
-            consent.data.consentId,
-            tppResource.tpp.registrationResponse,
-            psu,
-            tppResource.tpp
-        )
-        val accountId = AccountRS().getFirstAccountId(accountAndTransaction3_1_2.Links.links.GetAccounts, accessToken)
-
-        // When
-        val result = AccountRS().getAccountsData<OBReadBalance1>(
-            urlWithAccountId(
-                accountAndTransaction3_1_2.Links.links.GetAccountBalances,
-                accountId
-            ), accessToken
-        )
-
-        // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data.balance).isNotEmpty()
+       shouldGetBalances(OBVersion.v3_1_2)
     }
 
     @EnabledIfVersion(
@@ -68,36 +74,18 @@ class GetAccountBalancesTest(val tppResource: CreateTppCallback.TppResource) {
     )
     @Test
     fun shouldGetBalances_v3_1_8() {
-        // Given
-        val consentRequest = OBReadConsent1().data(
-            OBReadData1()
-                .permissions(listOf(READACCOUNTSDETAIL, READBALANCES))
-        )
-            .risk(OBRisk2())
-        val consent = AccountRS().consent<OBReadConsentResponse1>(
-            accountAndTransaction3_1_8.Links.links.CreateAccountAccessConsent,
-            consentRequest,
-            tppResource.tpp
-        )
-        val accessToken = AccountAS().getAccessToken(
-            consent.data.consentId,
-            tppResource.tpp.registrationResponse,
-            psu,
-            tppResource.tpp
-        )
-        val accountId = AccountRS().getFirstAccountId(accountAndTransaction3_1_8.Links.links.GetAccounts, accessToken)
-
-        // When
-        val result = AccountRS().getAccountsData<OBReadBalance1>(
-            urlWithAccountId(
-                accountAndTransaction3_1_8.Links.links.GetAccountBalances,
-                accountId
-            ), accessToken
-        )
-
-        // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data.balance).isNotEmpty()
+        shouldGetBalances(OBVersion.v3_1_8)
     }
 
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountBalances"],
+        apis = ["balances"],
+        compatibleVersions = ["v3.1.8", "v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+    )
+    @Test
+    fun shouldGetBalances_v3_1_9() {
+        shouldGetBalances(OBVersion.v3_1_9)
+    }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/CreateDomesticPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/CreateDomesticPaymentsConsentsTest.kt
@@ -34,7 +34,7 @@ import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFact
 /**
  * Tests for CreateDomesticPaymentConsent operations pre version 3.1.8
  *
- * The follow classes demonstrate the latest pattern:
+ * The following classes demonstrate the pattern to use for the lastest API versions:
  * @see CreateDomesticPaymentsConsentsv3_1_8Impl
  * @see CreateDomesticPaymentsConsentsv3_1_8Test
  */

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/CreateDomesticPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/CreateDomesticPaymentsConsentsTest.kt
@@ -15,7 +15,6 @@ import com.forgerock.securebanking.framework.signature.signPayloadSubmitPaymentI
 import com.forgerock.uk.openbanking.support.discovery.payment3_1_1
 import com.forgerock.uk.openbanking.support.discovery.payment3_1_3
 import com.forgerock.uk.openbanking.support.discovery.payment3_1_4
-import com.forgerock.uk.openbanking.support.discovery.payment3_1_8
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import com.forgerock.uk.openbanking.framework.constants.INVALID_FORMAT_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.constants.INVALID_SIGNING_KID
@@ -30,171 +29,17 @@ import org.junit.jupiter.api.Test
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse2
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse3
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse4
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory.*
 
+/**
+ * Tests for CreateDomesticPaymentConsent operations pre version 3.1.8
+ *
+ * The follow classes demonstrate the latest pattern:
+ * @see CreateDomesticPaymentsConsentsv3_1_8Impl
+ * @see CreateDomesticPaymentsConsentsv3_1_8Test
+ */
+@Deprecated("Tests for API versions < 3.1.8, such versions are expected to be dropped from support in the future")
 class CreateDomesticPaymentsConsentsTest(val tppResource: CreateTppCallback.TppResource) {
-
-    @EnabledIfVersion(
-        type = "payments",
-        apiVersion = "v3.1.8",
-        operations = ["CreateDomesticPaymentConsent"],
-        apis = ["domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
-    )
-    @Test
-    fun createDomesticPaymentsConsents_v3_1_8() {
-        // Given
-        val consentRequest = aValidOBWriteDomesticConsent4()
-        val signedPayloadConsent =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(consentRequest),
-                tppResource.tpp.signingKey,
-                tppResource.tpp.signingKid
-            )
-
-        // When
-        val consent = PaymentRS().consent<OBWriteDomesticConsentResponse5>(
-            payment3_1_8.Links.links.CreateDomesticPaymentConsent,
-            consentRequest,
-            tppResource.tpp,
-            OBVersion.v3_1_8,
-            signedPayloadConsent
-        )
-
-        // Then
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-    }
-
-    @EnabledIfVersion(
-        type = "payments",
-        apiVersion = "v3.1.8",
-        operations = ["CreateDomesticPaymentConsent"],
-        apis = ["domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
-    )
-    @Test
-    fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidFormatDetachedJws_v3_1_8() {
-        // Given
-        val consentRequest = aValidOBWriteDomesticConsent4()
-
-        // When
-        val exception = assertThrows(AssertionError::class.java) {
-            PaymentRS().consent<OBWriteDomesticConsentResponse5>(
-                payment3_1_8.Links.links.CreateDomesticPaymentConsent,
-                consentRequest,
-                tppResource.tpp,
-                OBVersion.v3_1_8,
-                INVALID_FORMAT_DETACHED_JWS
-            )
-        }
-
-        // Then
-        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
-        assertThat(exception.message.toString()).contains(INVALID_FORMAT_DETACHED_JWS_ERROR)
-    }
-
-    @EnabledIfVersion(
-        type = "payments",
-        apiVersion = "v3.1.8",
-        operations = ["CreateDomesticPaymentConsent"],
-        apis = ["domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
-    )
-    @Test
-    fun shouldCreateDomesticPaymentsConsents_throwsNoDetachedJws_v3_1_8() {
-        // Given
-        val consentRequest = aValidOBWriteDomesticConsent4()
-
-        // When
-        val exception = assertThrows(AssertionError::class.java) {
-            PaymentRS().consentNoDetachedJwt<OBWriteDomesticConsentResponse5>(
-                payment3_1_8.Links.links.CreateDomesticPaymentConsent,
-                consentRequest,
-                tppResource.tpp,
-                OBVersion.v3_1_8
-            )
-        }
-
-        // Then
-        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
-        assertThat(exception.message.toString()).contains(NO_DETACHED_JWS)
-    }
-
-    @EnabledIfVersion(
-        type = "payments",
-        apiVersion = "v3.1.8",
-        operations = ["CreateDomesticPaymentConsent"],
-        apis = ["domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
-    )
-    @Test
-    fun shouldCreateDomesticPaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_8() {
-        // Given
-        val consentRequest = aValidOBWriteDomesticConsent4()
-
-        val signedPayload =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(consentRequest),
-                tppResource.tpp.signingKey,
-                tppResource.tpp.signingKid,
-                true
-            )
-
-        // When
-        val exception = assertThrows(AssertionError::class.java) {
-            PaymentRS().consent<OBWriteDomesticConsentResponse5>(
-                payment3_1_8.Links.links.CreateDomesticPaymentConsent,
-                consentRequest,
-                tppResource.tpp,
-                OBVersion.v3_1_8,
-                signedPayload
-            )
-        }
-
-        // Then
-        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
-        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
-    }
-
-    @EnabledIfVersion(
-        type = "payments",
-        apiVersion = "v3.1.8",
-        operations = ["CreateDomesticPaymentConsent"],
-        apis = ["domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
-    )
-    @Test
-    fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidKidDetachedJws_v3_1_8() {
-        // Given
-        val consentRequest = aValidOBWriteDomesticConsent4()
-
-        val signedPayloadConsent =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(consentRequest),
-                tppResource.tpp.signingKey,
-                INVALID_SIGNING_KID
-            )
-
-        // When
-        val exception = assertThrows(AssertionError::class.java) {
-            PaymentRS().consent<OBWriteDomesticConsentResponse5>(
-                payment3_1_8.Links.links.CreateDomesticPaymentConsent,
-                consentRequest,
-                tppResource.tpp,
-                OBVersion.v3_1_8,
-                signedPayloadConsent
-            )
-        }
-
-        // Then
-        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
-        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
-    }
 
     @EnabledIfVersion(
         type = "payments",

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/CreateDomesticPaymentsConsentsv3_1_8Impl.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/CreateDomesticPaymentsConsentsv3_1_8Impl.kt
@@ -1,0 +1,151 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEmpty
+import assertk.assertions.isNotNull
+import com.forgerock.securebanking.framework.conditions.Status
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.http.fuel.defaultMapper
+import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.framework.constants.INVALID_FORMAT_DETACHED_JWS
+import com.forgerock.uk.openbanking.framework.constants.INVALID_SIGNING_KID
+import com.forgerock.uk.openbanking.framework.errors.INVALID_FORMAT_DETACHED_JWS_ERROR
+import com.forgerock.uk.openbanking.framework.errors.NO_DETACHED_JWS
+import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
+import com.forgerock.uk.openbanking.support.payment.PaymentRS
+import com.github.kittinunf.fuel.core.FuelError
+import org.assertj.core.api.Assertions
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5
+import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory
+
+/**
+ * Test routines which work when run against the v3.1.8 implementation of CreateDomesticPaymentConsent, and later
+ * versions which are functionally equivalent.
+ */
+class CreateDomesticPaymentsConsentsv3_1_8Impl(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
+
+    fun createDomesticPaymentsConsents() {
+        // Given
+        val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid
+            )
+
+        // When
+        val consent = PaymentRS().consent<OBWriteDomesticConsentResponse5>(
+            getPaymentsApiLinks(version).CreateDomesticPaymentConsent,
+            consentRequest,
+            tppResource.tpp,
+            version,
+            signedPayloadConsent
+        )
+
+        // Then
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consent.risk).isNotNull()
+    }
+
+    fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidFormatDetachedJws() {
+        // Given
+        val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
+
+        // When
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticConsentResponse5>(
+                getPaymentsApiLinks(version).CreateDomesticPaymentConsent,
+                consentRequest,
+                tppResource.tpp,
+                OBVersion.v3_1_8,
+                INVALID_FORMAT_DETACHED_JWS
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(INVALID_FORMAT_DETACHED_JWS_ERROR)
+    }
+
+    fun shouldCreateDomesticPaymentsConsents_throwsNoDetachedJws() {
+        // Given
+        val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
+
+        // When
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            PaymentRS().consentNoDetachedJwt<OBWriteDomesticConsentResponse5>(
+                getPaymentsApiLinks(version).CreateDomesticPaymentConsent,
+                consentRequest,
+                tppResource.tpp,
+                version
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(NO_DETACHED_JWS)
+    }
+
+    fun shouldCreateDomesticPaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws() {
+        // Given
+        val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
+
+        val signedPayload =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                tppResource.tpp.signingKid,
+                true
+            )
+
+        // When
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticConsentResponse5>(
+                getPaymentsApiLinks(version).CreateDomesticPaymentConsent,
+                consentRequest,
+                tppResource.tpp,
+                version,
+                signedPayload
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
+    }
+
+    fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidKidDetachedJws() {
+        // Given
+        val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
+
+        val signedPayloadConsent =
+            signPayloadSubmitPayment(
+                defaultMapper.writeValueAsString(consentRequest),
+                tppResource.tpp.signingKey,
+                INVALID_SIGNING_KID
+            )
+
+        // When
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            PaymentRS().consent<OBWriteDomesticConsentResponse5>(
+                getPaymentsApiLinks(version).CreateDomesticPaymentConsent,
+                consentRequest,
+                tppResource.tpp,
+                version,
+                signedPayloadConsent
+            )
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/CreateDomesticPaymentsConsentsv3_1_8Impl.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/CreateDomesticPaymentsConsentsv3_1_8Impl.kt
@@ -28,7 +28,10 @@ import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFact
  */
 class CreateDomesticPaymentsConsentsv3_1_8Impl(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
+    private val paymentLinks = getPaymentsApiLinks(version)
+
     fun createDomesticPaymentsConsents() {
+
         // Given
         val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
         val signedPayloadConsent =
@@ -40,7 +43,7 @@ class CreateDomesticPaymentsConsentsv3_1_8Impl(val version: OBVersion, val tppRe
 
         // When
         val consent = PaymentRS().consent<OBWriteDomesticConsentResponse5>(
-            getPaymentsApiLinks(version).CreateDomesticPaymentConsent,
+            paymentLinks.CreateDomesticPaymentConsent,
             consentRequest,
             tppResource.tpp,
             version,
@@ -62,10 +65,10 @@ class CreateDomesticPaymentsConsentsv3_1_8Impl(val version: OBVersion, val tppRe
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().consent<OBWriteDomesticConsentResponse5>(
-                getPaymentsApiLinks(version).CreateDomesticPaymentConsent,
+                paymentLinks.CreateDomesticPaymentConsent,
                 consentRequest,
                 tppResource.tpp,
-                OBVersion.v3_1_8,
+                version,
                 INVALID_FORMAT_DETACHED_JWS
             )
         }
@@ -82,7 +85,7 @@ class CreateDomesticPaymentsConsentsv3_1_8Impl(val version: OBVersion, val tppRe
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().consentNoDetachedJwt<OBWriteDomesticConsentResponse5>(
-                getPaymentsApiLinks(version).CreateDomesticPaymentConsent,
+                paymentLinks.CreateDomesticPaymentConsent,
                 consentRequest,
                 tppResource.tpp,
                 version
@@ -109,7 +112,7 @@ class CreateDomesticPaymentsConsentsv3_1_8Impl(val version: OBVersion, val tppRe
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().consent<OBWriteDomesticConsentResponse5>(
-                getPaymentsApiLinks(version).CreateDomesticPaymentConsent,
+                paymentLinks.CreateDomesticPaymentConsent,
                 consentRequest,
                 tppResource.tpp,
                 version,
@@ -136,7 +139,7 @@ class CreateDomesticPaymentsConsentsv3_1_8Impl(val version: OBVersion, val tppRe
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().consent<OBWriteDomesticConsentResponse5>(
-                getPaymentsApiLinks(version).CreateDomesticPaymentConsent,
+                paymentLinks.CreateDomesticPaymentConsent,
                 consentRequest,
                 tppResource.tpp,
                 version,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/CreateDomesticPaymentsConsentsv3_1_8Test.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/CreateDomesticPaymentsConsentsv3_1_8Test.kt
@@ -1,0 +1,71 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import org.junit.jupiter.api.Test
+
+class CreateDomesticPaymentsConsentsv3_1_8Test(val tppResource: CreateTppCallback.TppResource) {
+
+    private val version = OBVersion.v3_1_8
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createDomesticPaymentsConsents() {
+        CreateDomesticPaymentsConsentsv3_1_8Impl(version, tppResource).createDomesticPaymentsConsents()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidFormatDetachedJws() {
+        CreateDomesticPaymentsConsentsv3_1_8Impl(version, tppResource).shouldCreateDomesticPaymentsConsents_throwsSendInvalidFormatDetachedJws()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsNoDetachedJws() {
+        CreateDomesticPaymentsConsentsv3_1_8Impl(version, tppResource).shouldCreateDomesticPaymentsConsents_throwsNoDetachedJws()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws() {
+        CreateDomesticPaymentsConsentsv3_1_8Impl(version, tppResource).shouldCreateDomesticPaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidKidDetachedJws() {
+        CreateDomesticPaymentsConsentsv3_1_8Impl(version, tppResource).shouldCreateDomesticPaymentsConsents_throwsSendInvalidKidDetachedJws()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/CreateDomesticPaymentsConsentsv3_1_9Test.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/CreateDomesticPaymentsConsentsv3_1_9Test.kt
@@ -1,0 +1,71 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import org.junit.jupiter.api.Test
+
+class CreateDomesticPaymentsConsentsv3_1_9Test(val tppResource: CreateTppCallback.TppResource) {
+
+    private val version = OBVersion.v3_1_9
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createDomesticPaymentsConsents() {
+        CreateDomesticPaymentsConsentsv3_1_8Impl(version, tppResource).createDomesticPaymentsConsents()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidFormatDetachedJws() {
+        CreateDomesticPaymentsConsentsv3_1_8Impl(version, tppResource).shouldCreateDomesticPaymentsConsents_throwsSendInvalidFormatDetachedJws()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsNoDetachedJws() {
+        CreateDomesticPaymentsConsentsv3_1_8Impl(version, tppResource).shouldCreateDomesticPaymentsConsents_throwsNoDetachedJws()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws() {
+        CreateDomesticPaymentsConsentsv3_1_8Impl(version, tppResource).shouldCreateDomesticPaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidKidDetachedJws() {
+        CreateDomesticPaymentsConsentsv3_1_8Impl(version, tppResource).shouldCreateDomesticPaymentsConsents_throwsSendInvalidKidDetachedJws()
+    }
+}


### PR DESCRIPTION
Refactoring functional tests to support reusing test logic across multiple versions which are functionally identical

Versions 3.1.8 and 3.1.9 are functionally equivalent for all the schemas (except VRPs which we currently don't have tests for). We would like to be able to run tests against the different versions that we support to verify that the controllers behave identically.

Refactored tests to allow the version to be plugged in, which enables us to execute the same logic against different API endpoints.

GetAccountBalancesTest demonstrates how simple test cases can be refactored, extracting a single test method which the version can be plugged into. This works as both of the methods are identical except for the urls.

CreateDomesticPaymentsConsentsv3_1_8Impl, CreateDomesticPaymentsConsentsv3_1_8Test and CreateDomesticPaymentsConsentsv3_1_9Test demonstrate a pattern for more complex test cases where there are multiple test cases that we want to reuse. Here we extract a class with the test logic and have separate version specific Test classes which invoke the test methods from JUnit.

The existing CreateDomesticPaymentsConsentsTest class has marked as deprecated and only contains tests for versions prior to 3.1.8 - as it was deemed too much effort to refactor these when it is likely that we will drop support for older versions in the future.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/487