### PR TITLE
491: Disabling payments tests for API versions < 3.1.4

### DIFF
--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/CreateDomesticPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/CreateDomesticPaymentTest.kt
@@ -31,6 +31,7 @@ import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory.*
@@ -801,6 +802,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         apis = ["domestic-payments", "domestic-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPayments_throwsPaymentAlreadyExists_v3_1_4() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent4()
@@ -1386,6 +1388,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun createDomesticPayments_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent3()
@@ -1470,6 +1473,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPayments_throwsPaymentAlreadyExists_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent3()
@@ -1556,6 +1560,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPayments_throwsSendInvalidFormatDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent3()
@@ -1634,6 +1639,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPayments_throwsNoDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent3()
@@ -1709,6 +1715,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPayments_throwsSendInvalidKidDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent3()
@@ -1795,6 +1802,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPayments_throwsB64ClaimMissingDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent3()
@@ -1879,6 +1887,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPayments_throwsB64ClaimShouldBeFalseDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent3()
@@ -1963,6 +1972,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent3()
@@ -2054,6 +2064,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent3()
@@ -2145,6 +2156,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun createDomesticPayments_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent2()
@@ -2229,6 +2241,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPayments_throwsPaymentAlreadyExists_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent2()
@@ -2315,6 +2328,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPayments_throwsSendInvalidFormatDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent2()
@@ -2392,6 +2406,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPayments_throwsNoDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent2()
@@ -2467,6 +2482,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPayments_throwsSendInvalidKidDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent2()
@@ -2552,6 +2568,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPayments_throwsB64ClaimMissingDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent2()
@@ -2637,6 +2654,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPayments_throwsB64ClaimShouldBeFalseDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent2()
@@ -2722,6 +2740,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent2()
@@ -2813,6 +2832,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/GetDomesticPaymentDomesticPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/GetDomesticPaymentDomesticPaymentIdPaymentDetailsTest.kt
@@ -21,6 +21,7 @@ import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.map
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.urlWithDomesticPaymentId
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory.*
@@ -232,6 +233,7 @@ class GetDomesticPaymentDomesticPaymentIdPaymentDetailsTest(val tppResource: Cre
         apis = ["domestic-payments", "domestic-payment-consents"]
     )
     @Test
+    @Disabled
     fun getDomesticPaymentDomesticPaymentIdPaymentDetails_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent3()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/GetDomesticPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/GetDomesticPaymentTest.kt
@@ -459,6 +459,7 @@ class GetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) {
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun getDomesticPayments_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent3()
@@ -562,6 +563,7 @@ class GetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) {
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun getDomesticPayments_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/CreateDomesticPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/CreateDomesticPaymentsConsentsTest.kt
@@ -26,6 +26,7 @@ import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse2
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse3
@@ -325,6 +326,7 @@ class CreateDomesticPaymentsConsentsTest(val tppResource: CreateTppCallback.TppR
         apis = ["domestic-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidKidDetachedJws_v3_1_4() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent4()
@@ -361,6 +363,7 @@ class CreateDomesticPaymentsConsentsTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun createDomesticPaymentsConsents_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent3()
@@ -452,6 +455,7 @@ class CreateDomesticPaymentsConsentsTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidKidDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent3()
@@ -559,6 +563,7 @@ class CreateDomesticPaymentsConsentsTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun createDomesticPaymentsConsents_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent2()
@@ -650,6 +655,7 @@ class CreateDomesticPaymentsConsentsTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidKidDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/GetDomesticPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/GetDomesticPaymentsConsentFundsConfirmationTest.kt
@@ -371,6 +371,7 @@ class GetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: CreateTpp
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldGetDomesticPaymentConsentsFundsConfirmation_true_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent3()
@@ -429,6 +430,7 @@ class GetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: CreateTpp
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldGetDomesticPaymentConsentsFundsConfirmation_false_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent3()
@@ -539,6 +541,7 @@ class GetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: CreateTpp
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldGetDomesticPaymentConsentsFundsConfirmation_true_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent2()
@@ -597,6 +600,7 @@ class GetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: CreateTpp
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldGetDomesticPaymentConsentsFundsConfirmation_false_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/GetDomesticPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/GetDomesticPaymentsConsentsTest.kt
@@ -18,6 +18,7 @@ import com.forgerock.uk.openbanking.support.discovery.payment3_1_8
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse2
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse3
@@ -244,6 +245,7 @@ class GetDomesticPaymentsConsentsTest(val tppResource: CreateTppCallback.TppReso
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldGetDomesticPaymentsConsents_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent3()
@@ -295,6 +297,7 @@ class GetDomesticPaymentsConsentsTest(val tppResource: CreateTppCallback.TppReso
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldGetDomesticPaymentsConsents_withoutOptionalDebtorAccount_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent3()
@@ -349,6 +352,7 @@ class GetDomesticPaymentsConsentsTest(val tppResource: CreateTppCallback.TppReso
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldGetDomesticPaymentsConsents_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent2()
@@ -400,6 +404,7 @@ class GetDomesticPaymentsConsentsTest(val tppResource: CreateTppCallback.TppReso
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldGetDomesticPaymentsConsents_withoutOptionalDebtorAccount_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/CreateDomesticScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/CreateDomesticScheduledPaymentTest.kt
@@ -1396,6 +1396,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun createDomesticScheduledPayments_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent3()
@@ -1574,6 +1575,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticScheduledPayments_throwsSendInvalidFormatDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent3()
@@ -1652,6 +1654,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticScheduledPayments_throwsNoDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent3()
@@ -1727,6 +1730,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticScheduledPayments_throwsSendInvalidKidDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent3()
@@ -1813,6 +1817,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticScheduledPayments_throwsB64ClaimMissingDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent3()
@@ -1897,6 +1902,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticScheduledPayments_throwsB64ClaimShouldBeFalseDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent3()
@@ -1981,6 +1987,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent3()
@@ -2072,6 +2079,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent3()
@@ -2163,6 +2171,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun createDomesticScheduledPayments_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent2()
@@ -2341,6 +2350,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticScheduledPayments_throwsSendInvalidFormatDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent2()
@@ -2418,6 +2428,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticScheduledPayments_throwsNoDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent2()
@@ -2493,6 +2504,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticScheduledPayments_throwsSendInvalidKidDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent2()
@@ -2578,6 +2590,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticScheduledPayments_throwsB64ClaimMissingDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent2()
@@ -2663,6 +2676,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticScheduledPayments_throwsB64ClaimShouldBeFalseDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent2()
@@ -2748,6 +2762,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent2()
@@ -2839,6 +2854,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest.kt
@@ -19,6 +19,7 @@ import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.urlWithDomesticScheduledPaymentId
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent3
@@ -231,6 +232,7 @@ class GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest(val tppReso
         apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun getDomesticScheduledPaymentDomesticPaymentIdPaymentDetails_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent3()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/GetDomesticScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/GetDomesticScheduledPaymentTest.kt
@@ -458,6 +458,7 @@ class GetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppReso
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun getDomesticScheduledPayments_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent3()
@@ -561,6 +562,7 @@ class GetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppReso
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun getDomesticScheduledPayments_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/CreateDomesticScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/CreateDomesticScheduledPaymentsConsentsTest.kt
@@ -24,6 +24,7 @@ import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
 import org.joda.time.DateTime
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse2
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse3
@@ -359,6 +360,7 @@ class CreateDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCall
         apis = ["domestic-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticScheduledPaymentsConsents_throwsSendInvalidKidDetachedJws_v3_1_4() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent4()
@@ -431,6 +433,7 @@ class CreateDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCall
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun createDomesticScheduledPaymentsConsents_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent3()
@@ -522,6 +525,7 @@ class CreateDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCall
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticScheduledPaymentsConsents_throwsSendInvalidKidDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent3()
@@ -665,6 +669,7 @@ class CreateDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCall
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun createDomesticScheduledPaymentsConsents_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent2()
@@ -756,6 +761,7 @@ class CreateDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCall
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticScheduledPaymentsConsents_throwsSendInvalidKidDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/GetDomesticScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/GetDomesticScheduledPaymentsConsentsTest.kt
@@ -18,6 +18,7 @@ import com.forgerock.uk.openbanking.support.discovery.payment3_1_8
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse2
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse3
@@ -244,6 +245,7 @@ class GetDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCallbac
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldGetDomesticScheduledPaymentsConsents_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent3()
@@ -295,6 +297,7 @@ class GetDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCallbac
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldGetDomesticScheduledPaymentsConsents_withoutOptionalDebtorAccount_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent3()
@@ -349,6 +352,7 @@ class GetDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCallbac
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldGetDomesticScheduledPaymentsConsents_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent2()
@@ -400,6 +404,7 @@ class GetDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCallbac
         compatibleVersions = ["v.3.1"]
     )
     @Test
+    @Disabled
     fun shouldGetDomesticScheduledPaymentsConsents_withoutOptionalDebtorAccount_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticScheduledConsent2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/CreateDomesticStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/CreateDomesticStandingOrderTest.kt
@@ -1558,6 +1558,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun createDomesticStandingOrder_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
@@ -1642,6 +1643,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun createDomesticStandingOrder_v3_1_3_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent4MandatoryFields()
@@ -1820,6 +1822,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrder_throwsSendInvalidFormatDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
@@ -1898,6 +1901,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrder_throwsNoDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
@@ -1973,6 +1977,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrder_throwsSendInvalidKidDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
@@ -2059,6 +2064,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrder_throwsB64ClaimMissingDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
@@ -2143,6 +2149,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrder_throwsB64ClaimShouldBeFalseDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
@@ -2227,6 +2234,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
@@ -2318,6 +2326,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
@@ -2408,6 +2417,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun createDomesticStandingOrder_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
@@ -2492,6 +2502,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun createDomesticStandingOrder_v3_1_1_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent3MandatoryFields()
@@ -2669,6 +2680,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrder_throwsSendInvalidFormatDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
@@ -2745,6 +2757,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrder_throwsNoDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
@@ -2819,6 +2832,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrder_throwsSendInvalidKidDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
@@ -2903,6 +2917,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrder_throwsB64ClaimMissingDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
@@ -2987,6 +3002,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrder_throwsB64ClaimShouldBeFalseDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
@@ -3071,6 +3087,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
@@ -3161,6 +3178,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
@@ -3251,6 +3269,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun createDomesticStandingOrder_v3_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()
@@ -3335,6 +3354,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun createDomesticStandingOrder_v3_1_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent2MandatoryFields()
@@ -3591,6 +3611,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrder_throwsNoDetachedJws_v3_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()
@@ -3750,6 +3771,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrder_throwsB64ClaimMissingDetachedJws_v3_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()
@@ -4008,6 +4030,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/CreateDomesticStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/CreateDomesticStandingOrderTest.kt
@@ -3856,6 +3856,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrder_throwsB64ClaimShouldBeFalseDetachedJws_v3_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest.kt
@@ -19,6 +19,7 @@ import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.urlWithDomesticStandingOrderId
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsentTestDataFactory.*
@@ -428,6 +429,7 @@ class GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest(val tppR
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
@@ -529,6 +531,7 @@ class GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest(val tppR
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails_v3_1_3_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent4MandatoryFields()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/GetDomesticStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/GetDomesticStandingOrderTest.kt
@@ -663,6 +663,7 @@ class GetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppResourc
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun getDomesticStandingOrders_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
@@ -766,6 +767,7 @@ class GetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppResourc
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun getDomesticStandingOrders_v3_1_3_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent4MandatoryFields()
@@ -868,6 +870,7 @@ class GetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppResourc
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun getDomesticStandingOrders_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
@@ -974,6 +977,7 @@ class GetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppResourc
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun getDomesticStandingOrders_v3_1_1_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent3MandatoryFields()
@@ -1080,6 +1084,7 @@ class GetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppResourc
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun getDomesticStandingOrders_v3_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()
@@ -1182,6 +1187,7 @@ class GetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppResourc
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun getDomesticStandingOrders_v3_1_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent2MandatoryFields()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/CreateDomesticStandingOrderConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/CreateDomesticStandingOrderConsentsTest.kt
@@ -21,6 +21,7 @@ import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsentTestDataFactory.*
@@ -455,6 +456,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         apis = ["domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidKidDetachedJws_v3_1_4() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent5()
@@ -490,6 +492,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun createDomesticStandingOrdersConsents_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
@@ -527,6 +530,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun createDomesticStandingOrdersConsents_mandatoryFields_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent4MandatoryFields()
@@ -564,6 +568,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrdersConsents_throwsInvalidFrequencyValue_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
@@ -655,6 +660,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidKidDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
@@ -761,6 +767,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         apis = ["domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun createDomesticStandingOrdersConsents_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
@@ -797,6 +804,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         apis = ["domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun createDomesticStandingOrdersConsents_mandatoryFields_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent3MandatoryFields()
@@ -834,6 +842,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         apis = ["domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrdersConsents_throwsInvalidFrequencyValue_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
@@ -922,6 +931,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         apis = ["domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidKidDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
@@ -1025,6 +1035,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         apis = ["domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun createDomesticStandingOrdersConsents_v3_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()
@@ -1061,6 +1072,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         apis = ["domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun createDomesticStandingOrdersConsents_mandatoryFields_v3_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent2MandatoryFields()
@@ -1097,6 +1109,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         apis = ["domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrdersConsents_throwsInvalidFrequencyValue_v3_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()
@@ -1186,6 +1199,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         apis = ["domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidKidDetachedJws_v3_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()
@@ -1221,6 +1235,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         apis = ["domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateDomesticStandingOrdersConsents_throwsB64ClaimMissingDetachedJws_v3_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/GetDomesticStandingOrderConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/GetDomesticStandingOrderConsentsTest.kt
@@ -14,6 +14,7 @@ import com.forgerock.uk.openbanking.support.discovery.*
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsentTestDataFactory.*
@@ -128,6 +129,7 @@ class GetDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback.Tp
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun shouldGetDomesticStandingOrdersConsents_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent4()
@@ -179,6 +181,7 @@ class GetDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback.Tp
         apis = ["domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetDomesticStandingOrdersConsents_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent3()
@@ -230,6 +233,7 @@ class GetDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback.Tp
         apis = ["domestic-standing-order-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetDomesticStandingOrdersConsents_v3_1() {
         // Given
         val consentRequest = aValidOBWriteDomesticStandingOrderConsent2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/CreateInternationalPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/CreateInternationalPaymentTest.kt
@@ -29,6 +29,7 @@ import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory.*
@@ -1900,6 +1901,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPayment_rateType_AGREED_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -1985,6 +1987,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPayment_rateType_ACTUAL_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -2071,6 +2074,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPayment_rateType_INDICATIVE_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -2157,6 +2161,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPayment_v3_1_3_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4MandatoryFields()
@@ -2240,6 +2245,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsInternationalPaymentAlreadyExists_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -2332,6 +2338,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsSendInvalidFormatDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -2409,6 +2416,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsNoDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -2483,6 +2491,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsSendInvalidKidDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -2568,6 +2577,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsB64ClaimMissingDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -2651,6 +2661,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsB64ClaimShouldBeFalseDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -2734,6 +2745,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -2824,6 +2836,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -2914,6 +2927,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPayment_rateType_AGREED_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -2999,6 +3013,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPayment_rateType_ACTUAL_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -3085,6 +3100,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPayment_rateType_INDICATIVE_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -3171,6 +3187,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPayment_v3_1_2_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3MandatoryFields()
@@ -3254,6 +3271,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsInternationalPaymentAlreadyExists_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -3346,6 +3364,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsSendInvalidFormatDetachedJws_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -3423,6 +3442,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsNoDetachedJws_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -3497,6 +3517,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsSendInvalidKidDetachedJws_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -3582,6 +3603,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsB64ClaimMissingDetachedJws_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -3665,6 +3687,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsB64ClaimShouldBeFalseDetachedJws_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -3748,6 +3771,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -3838,6 +3862,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -3928,6 +3953,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPayment_rateType_AGREED_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -4014,6 +4040,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPayment_rateType_ACTUAL_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -4101,6 +4128,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPayment_rateType_INDICATIVE_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -4188,6 +4216,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPayment_v3_1_1_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3MandatoryFields()
@@ -4273,6 +4302,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsInternationalPaymentAlreadyExists_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -4365,6 +4395,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsSendInvalidFormatDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -4441,6 +4472,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsNoDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -4515,6 +4547,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsSendInvalidKidDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -4599,6 +4632,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsB64ClaimMissingDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -4683,6 +4717,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsB64ClaimShouldBeFalseDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -4767,6 +4802,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -4857,6 +4893,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -4947,6 +4984,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPayment_rateType_AGREED_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent2()
@@ -5033,6 +5071,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPayment_rateType_ACTUAL_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent2()
@@ -5120,6 +5159,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPayment_rateType_INDICATIVE_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent2()
@@ -5207,6 +5247,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPayment_v3_1_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent2MandatoryFields()
@@ -5292,6 +5333,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsInternationalPaymentAlreadyExists_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent2()
@@ -5622,6 +5664,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsB64ClaimMissingDetachedJws_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent2()
@@ -5880,6 +5923,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/GetInternationalPaymentInternationalPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/GetInternationalPaymentInternationalPaymentIdPaymentDetailsTest.kt
@@ -18,6 +18,7 @@ import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.map
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.urlWithInternationalPaymentId
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory.*
@@ -839,6 +840,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val tppRes
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_AGREED_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -942,6 +944,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val tppRes
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_ACTUAL_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -1046,6 +1049,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val tppRes
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_INDICATIVE_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -1150,6 +1154,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val tppRes
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalPaymentInternationalPaymentIdPaymentDetails_v3_1_3_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4MandatoryFields()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/GetInternationalPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/GetInternationalPaymentTest.kt
@@ -1081,6 +1081,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun getInternationalPayments_rateType_AGREED_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -1187,6 +1188,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun getInternationalPayments_rateType_ACTUAL_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -1293,6 +1295,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun getInternationalPayments_rateType_INDICATIVE_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -1399,6 +1402,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun getInternationalPayments_v3_1_3_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4MandatoryFields()
@@ -1501,6 +1505,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalPayments_rateType_AGREED_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -1606,6 +1611,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalPayments_rateType_ACTUAL_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -1711,6 +1717,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalPayments_rateType_INDICATIVE_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -1816,6 +1823,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalPayments_v3_1_2_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3MandatoryFields()
@@ -1918,6 +1926,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalPayments_rateType_AGREED_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -2027,6 +2036,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalPayments_rateType_ACTUAL_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -2136,6 +2146,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalPayments_rateType_INDICATIVE_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -2246,6 +2257,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalPayments_v3_1_1_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3MandatoryFields()
@@ -2352,6 +2364,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalPayments_rateType_AGREED_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent2()
@@ -2457,6 +2470,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalPayments_rateType_ACTUAL_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent2()
@@ -2562,6 +2576,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalPayments_rateType_INDICATIVE_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent2()
@@ -2667,6 +2682,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         apis = ["international-payments", "international-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalPayments_v3_1_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent2MandatoryFields()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/CreateInternationalPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/CreateInternationalPaymentsConsentsTest.kt
@@ -23,6 +23,7 @@ import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory.*
@@ -388,6 +389,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPaymentConsents_throwsSendInvalidKidDetachedJws_v3_1_4() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent5()
@@ -422,6 +424,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPaymentsConsents_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -458,6 +461,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPaymentsConsents_mandatoryFields_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4MandatoryFields()
@@ -547,6 +551,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPaymentConsents_throwsSendInvalidKidDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -651,6 +656,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPaymentsConsents_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -687,6 +693,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPaymentsConsents_mandatoryFields_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3MandatoryFields()
@@ -776,6 +783,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPaymentConsents_throwsSendInvalidKidDetachedJws_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -880,6 +888,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPaymentsConsents_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -916,6 +925,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPaymentsConsents_mandatoryFields_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3MandatoryFields()
@@ -1005,6 +1015,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPaymentConsents_throwsSendInvalidKidDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -1108,6 +1119,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPaymentsConsents_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent2()
@@ -1144,6 +1156,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalPaymentsConsents_mandatoryFields_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent2MandatoryFields()
@@ -1233,6 +1246,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPaymentConsents_throwsSendInvalidKidDetachedJws_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent2()
@@ -1268,6 +1282,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalPaymentConsents_throwsB64ClaimMissingDetachedJws_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/GetInternationalPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/GetInternationalPaymentsConsentsTest.kt
@@ -14,6 +14,7 @@ import com.forgerock.uk.openbanking.support.discovery.*
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory.*
@@ -347,6 +348,7 @@ class GetInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalPaymentsConsents_rateType_AGREED_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -400,6 +402,7 @@ class GetInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalPaymentsConsents_rateType_ACTUAL_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -455,6 +458,7 @@ class GetInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalPaymentsConsents_rateType_INDICATIVE_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent4()
@@ -509,6 +513,7 @@ class GetInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalPaymentsConsents_rateType_AGREED_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -562,6 +567,7 @@ class GetInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalPaymentsConsents_rateType_ACTUAL_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -617,6 +623,7 @@ class GetInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalPaymentsConsents_rateType_INDICATIVE_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -671,6 +678,7 @@ class GetInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalPaymentsConsents_rateType_AGREED_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -724,6 +732,7 @@ class GetInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalPaymentsConsents_rateType_ACTUAL_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -778,6 +787,7 @@ class GetInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalPaymentsConsents_rateType_INDICATIVE_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent3()
@@ -829,6 +839,7 @@ class GetInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalPaymentsConsents_rateType_AGREED_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent2()
@@ -881,6 +892,7 @@ class GetInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalPaymentsConsents_rateType_ACTUAL_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent2()
@@ -935,6 +947,7 @@ class GetInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalPaymentsConsents_rateType_INDICATIVE_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/CreateInternationalScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/CreateInternationalScheduledPaymentTest.kt
@@ -1955,6 +1955,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPayment_rateType_AGREED_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -2040,6 +2041,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPayment_rateType_ACTUAL_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -2126,6 +2128,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPayment_rateType_INDICATIVE_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -2212,6 +2215,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPayment_v3_1_3_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4MandatoryFields()
@@ -2388,6 +2392,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsSendInvalidFormatDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -2465,6 +2470,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsNoDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -2539,6 +2545,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsSendInvalidKidDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -2624,6 +2631,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsB64ClaimMissingDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -2707,6 +2715,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsB64ClaimShouldBeFalseDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -2790,6 +2799,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -2880,6 +2890,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -2970,6 +2981,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPayment_rateType_AGREED_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -3059,6 +3071,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPayment_rateType_ACTUAL_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -3149,6 +3162,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPayment_rateType_INDICATIVE_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -3239,6 +3253,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPayment_v3_1_2_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3MandatoryFields()
@@ -3423,6 +3438,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsSendInvalidFormatDetachedJws_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -3504,6 +3520,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsNoDetachedJws_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -3582,6 +3599,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsSendInvalidKidDetachedJws_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -3671,6 +3689,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsB64ClaimMissingDetachedJws_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -3758,6 +3777,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsB64ClaimShouldBeFalseDetachedJws_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -3845,6 +3865,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -3943,6 +3964,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -4041,6 +4063,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPayment_rateType_AGREED_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -4131,6 +4154,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPayment_rateType_ACTUAL_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -4222,6 +4246,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPayment_rateType_INDICATIVE_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -4313,6 +4338,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPayment_v3_1_1_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3MandatoryFields()
@@ -4498,6 +4524,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsSendInvalidFormatDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -4578,6 +4605,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsNoDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -4656,6 +4684,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsSendInvalidKidDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -4744,6 +4773,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsB64ClaimMissingDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -4832,6 +4862,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsB64ClaimShouldBeFalseDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -4920,6 +4951,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -5018,6 +5050,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -5116,6 +5149,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPayment_rateType_AGREED_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent2()
@@ -5202,6 +5236,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPayment_rateType_ACTUAL_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent2()
@@ -5289,6 +5324,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPayment_rateType_INDICATIVE_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent2()
@@ -5376,6 +5412,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPayment_v3_1_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent2MandatoryFields()
@@ -5791,6 +5828,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsB64ClaimMissingDetachedJws_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent2()
@@ -6049,6 +6087,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/GetInternationalScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/GetInternationalScheduledPaymentTest.kt
@@ -1102,6 +1102,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun getInternationalScheduledPayments_rateType_AGREED_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -1208,6 +1209,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun getInternationalScheduledPayments_rateType_ACTUAL_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -1314,6 +1316,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun getInternationalScheduledPayments_rateType_INDICATIVE_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -1420,6 +1423,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         compatibleVersions = ["v.3.1.2"]
     )
     @Test
+    @Disabled
     fun getInternationalScheduledPayments_v3_1_3_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4MandatoryFields()
@@ -1522,6 +1526,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalScheduledPayments_rateType_AGREED_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -1631,6 +1636,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalScheduledPayments_rateType_ACTUAL_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -1740,6 +1746,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalScheduledPayments_rateType_INDICATIVE_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -1849,6 +1856,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalScheduledPayments_v3_1_2_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3MandatoryFields()
@@ -1955,6 +1963,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalScheduledPayments_rateType_AGREED_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -2064,6 +2073,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalScheduledPayments_rateType_ACTUAL_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -2173,6 +2183,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalScheduledPayments_rateType_INDICATIVE_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -2283,6 +2294,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalScheduledPayments_v3_1_1_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3MandatoryFields()
@@ -2389,6 +2401,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalScheduledPayments_rateType_AGREED_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent2()
@@ -2494,6 +2507,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalScheduledPayments_rateType_ACTUAL_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent2()
@@ -2599,6 +2613,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalScheduledPayments_rateType_INDICATIVE_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent2()
@@ -2704,6 +2719,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun getInternationalScheduledPayments_v3_1_mandatoryFields() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent2MandatoryFields()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/CreateInternationalScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/CreateInternationalScheduledPaymentsConsentsTest.kt
@@ -21,6 +21,7 @@ import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
 import org.joda.time.DateTime
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory.*
@@ -445,8 +446,8 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         }
 
         // Then
-        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
-        assertThat(exception.message.toString()).contains(SIGNATURE_VALIDATION_FAILED)
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
     }
 
     @EnabledIfVersion(
@@ -491,6 +492,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPaymentsConsents_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -527,6 +529,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPaymentsConsents_mandatoryFields_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4MandatoryFields()
@@ -616,6 +619,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPaymentConsents_throwsSendInvalidKidDetachedJws_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -720,6 +724,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPaymentConsents_throwsRequestExecutionTimeInThePast_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -756,6 +761,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPaymentsConsents_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -792,6 +798,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPaymentsConsents_mandatoryFields_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3MandatoryFields()
@@ -881,6 +888,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPaymentConsents_throwsSendInvalidKidDetachedJws_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -985,6 +993,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPaymentConsents_throwsRequestExecutionTimeInThePast_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -1021,6 +1030,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPaymentsConsents_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -1057,6 +1067,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPaymentsConsents_mandatoryFields_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3MandatoryFields()
@@ -1146,6 +1157,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPaymentConsents_throwsSendInvalidKidDetachedJws_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -1249,6 +1261,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPaymentConsents_throwsRequestExecutionTimeInThePast_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -1285,6 +1298,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPaymentsConsents_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent2()
@@ -1321,6 +1335,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun createInternationalScheduledPaymentsConsents_mandatoryFields_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent2MandatoryFields()
@@ -1410,6 +1425,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPaymentConsents_throwsSendInvalidKidDetachedJws_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent2()
@@ -1445,6 +1461,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPaymentConsents_throwsB64ClaimMissingDetachedJws_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent2()
@@ -1513,6 +1530,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldCreateInternationalScheduledPaymentConsents_throwsRequestExecutionTimeInThePast_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent2()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/GetInternationalScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/GetInternationalScheduledPaymentsConsentsTest.kt
@@ -14,6 +14,7 @@ import com.forgerock.uk.openbanking.support.discovery.*
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory.*
@@ -347,6 +348,7 @@ class GetInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCa
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_AGREED_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -400,6 +402,7 @@ class GetInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCa
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_ACTUAL_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -455,6 +458,7 @@ class GetInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCa
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_INDICATIVE_v3_1_3() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent4()
@@ -509,6 +513,7 @@ class GetInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCa
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_AGREED_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -562,6 +567,7 @@ class GetInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCa
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_ACTUAL_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -617,6 +623,7 @@ class GetInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCa
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_INDICATIVE_v3_1_2() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -671,6 +678,7 @@ class GetInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCa
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_AGREED_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -724,6 +732,7 @@ class GetInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCa
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_ACTUAL_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -778,6 +787,7 @@ class GetInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCa
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_INDICATIVE_v3_1_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent3()
@@ -829,6 +839,7 @@ class GetInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCa
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_AGREED_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent2()
@@ -881,6 +892,7 @@ class GetInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCa
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_ACTUAL_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent2()
@@ -935,6 +947,7 @@ class GetInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCa
         apis = ["international-scheduled-payment-consents"]
     )
     @Test
+    @Disabled
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_INDICATIVE_v3_1() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent2()


### PR DESCRIPTION
Versions < 3.1.4 are not supported for payments at the moment, these tests have been disabled so they do not get run as part of the default test configuration.

Fixing bug in shouldCreateInternationalScheduledPaymentConsents_throwsSendInvalidKidDetachedJws_v3_1_4 which appears to be a copy paste error

Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/491