### PR TITLE
440 obie 3.1.9 tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("javax.xml.bind:jaxb-api:2.3.1")
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
-    implementation(platform("com.forgerock.securebanking.uk:securebanking-openbanking-uk-bom:1.1.3-SNAPSHOT"))
+    implementation(platform("com.forgerock.securebanking.uk:securebanking-openbanking-uk-bom:1.1.4-SNAPSHOT"))
     implementation("com.forgerock.securebanking.uk:securebanking-openbanking-uk-common")
     implementation("com.forgerock.securebanking.uk:securebanking-openbanking-uk-obie-datamodel")
     implementation("com.forgerock.securebanking.uk:securebanking-openbanking-uk-forgerock-datamodel")

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/access/consents/junit/v3_1_9/AccountAccessConsentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/access/consents/junit/v3_1_9/AccountAccessConsentTest.kt
@@ -1,0 +1,51 @@
+package com.forgerock.uk.openbanking.tests.functional.account.access.consents.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.access.consents.api.v3_1_8.AccountAccessConsent
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AccountAccessConsentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var accountAccessConsentApi: AccountAccessConsent
+
+    @BeforeEach
+    fun setUp() {
+        accountAccessConsentApi = AccountAccessConsent(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3", "v.3.1.2", "v.3.1.1", "v.3.1", "v.3.0"]
+    )
+    @Test
+    fun createAccountAccessConsents_v3_1_9() {
+        accountAccessConsentApi.createAccountAccessConsentTest()
+    }
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["DeleteAccountAccessConsent"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3", "v.3.1.2", "v.3.1.1", "v.3.1", "v.3.0"]
+    )
+    @Test
+    fun deleteAccountAccessConsents_v3_1_9() {
+        accountAccessConsentApi.deleteAccountAccessConsentTest()
+    }
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["GetAccountAccessConsent"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3", "v.3.1.2", "v.3.1.1", "v.3.1", "v.3.0"]
+    )
+    @Test
+    fun getAccountAccessConsents_v3_1_9() {
+        accountAccessConsentApi.getAccountAccessConsentTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/access/consents/junit/v3_1_9/AccountAccessConsentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/access/consents/junit/v3_1_9/AccountAccessConsentTest.kt
@@ -19,8 +19,7 @@ class AccountAccessConsentTest(val tppResource: CreateTppCallback.TppResource) {
     @EnabledIfVersion(
         type = "accounts",
         apiVersion = "v3.1.9",
-        operations = ["CreateAccountAccessConsent"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3", "v.3.1.2", "v.3.1.1", "v.3.1", "v.3.0"]
+        operations = ["CreateAccountAccessConsent"]
     )
     @Test
     fun createAccountAccessConsents_v3_1_9() {
@@ -30,8 +29,7 @@ class AccountAccessConsentTest(val tppResource: CreateTppCallback.TppResource) {
     @EnabledIfVersion(
         type = "accounts",
         apiVersion = "v3.1.9",
-        operations = ["DeleteAccountAccessConsent"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3", "v.3.1.2", "v.3.1.1", "v.3.1", "v.3.0"]
+        operations = ["DeleteAccountAccessConsent"]
     )
     @Test
     fun deleteAccountAccessConsents_v3_1_9() {
@@ -41,8 +39,7 @@ class AccountAccessConsentTest(val tppResource: CreateTppCallback.TppResource) {
     @EnabledIfVersion(
         type = "accounts",
         apiVersion = "v3.1.9",
-        operations = ["GetAccountAccessConsent"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3", "v.3.1.2", "v.3.1.1", "v.3.1", "v.3.0"]
+        operations = ["GetAccountAccessConsent"]
     )
     @Test
     fun getAccountAccessConsents_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/accounts/junit/v3_1_9/GetAccountTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/accounts/junit/v3_1_9/GetAccountTest.kt
@@ -13,8 +13,7 @@ class GetAccountTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccount"],
-        apis = ["accounts"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6"]
+        apis = ["accounts"]
     )
     @Test
     fun shouldGetAccount_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/accounts/junit/v3_1_9/GetAccountTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/accounts/junit/v3_1_9/GetAccountTest.kt
@@ -1,0 +1,23 @@
+package com.forgerock.uk.openbanking.tests.functional.account.accounts.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.accounts.api.v3_1_8.GetAccount
+import org.junit.jupiter.api.Test
+
+
+class GetAccountTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccount"],
+        apis = ["accounts"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6"]
+    )
+    @Test
+    fun shouldGetAccount_v3_1_9() {
+        GetAccount(OBVersion.v3_1_9, tppResource).shouldGetAccountTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/accounts/junit/v3_1_9/GetAccountsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/accounts/junit/v3_1_9/GetAccountsTest.kt
@@ -13,8 +13,7 @@ class GetAccountsTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts"],
-        apis = ["accounts"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6"]
+        apis = ["accounts"]
     )
     @Test
     fun shouldGetAccounts_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/accounts/junit/v3_1_9/GetAccountsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/accounts/junit/v3_1_9/GetAccountsTest.kt
@@ -1,0 +1,23 @@
+package com.forgerock.uk.openbanking.tests.functional.account.accounts.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.accounts.api.v3_1_8.GetAccounts
+import org.junit.jupiter.api.Test
+
+
+class GetAccountsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts"],
+        apis = ["accounts"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6"]
+    )
+    @Test
+    fun shouldGetAccounts_v3_1_9() {
+        GetAccounts(OBVersion.v3_1_9, tppResource).shouldGetAccountsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/balances/junit/v3_1_9/GetAccountBalancesTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/balances/junit/v3_1_9/GetAccountBalancesTest.kt
@@ -1,0 +1,22 @@
+package com.forgerock.uk.openbanking.tests.functional.account.balances.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.balances.api.v3_1_8.GetAccountBalances
+import org.junit.jupiter.api.Test
+
+class GetAccountBalancesTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountBalances"],
+        apis = ["balances"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+    )
+    @Test
+    fun shouldGetAccountBalances_v3_1_9() {
+        GetAccountBalances(OBVersion.v3_1_9, tppResource).shouldGetAccountBalancesTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/balances/junit/v3_1_9/GetAccountBalancesTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/balances/junit/v3_1_9/GetAccountBalancesTest.kt
@@ -12,8 +12,7 @@ class GetAccountBalancesTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountBalances"],
-        apis = ["balances"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+        apis = ["balances"]
     )
     @Test
     fun shouldGetAccountBalances_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/balances/junit/v3_1_9/GetBalancesTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/balances/junit/v3_1_9/GetBalancesTest.kt
@@ -12,8 +12,7 @@ class GetBalancesTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetBalances"],
-        apis = ["balances"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+        apis = ["balances"]
     )
     @Test
     fun shouldGetBalances_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/balances/junit/v3_1_9/GetBalancesTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/balances/junit/v3_1_9/GetBalancesTest.kt
@@ -1,0 +1,22 @@
+package com.forgerock.uk.openbanking.tests.functional.account.balances.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.balances.api.v3_1_8.GetBalances
+import org.junit.jupiter.api.Test
+
+class GetBalancesTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetBalances"],
+        apis = ["balances"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+    )
+    @Test
+    fun shouldGetBalances_v3_1_9() {
+        GetBalances(OBVersion.v3_1_9, tppResource).shouldGetBalancesTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/beneficiaries/junit/v3_1_9/GetAccountBeneficiariesTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/beneficiaries/junit/v3_1_9/GetAccountBeneficiariesTest.kt
@@ -1,0 +1,22 @@
+package com.forgerock.uk.openbanking.tests.functional.account.beneficiaries.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.beneficiaries.api.v3_1_8.GetAccountBeneficiaries
+import org.junit.jupiter.api.Test
+
+class GetAccountBeneficiariesTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountBeneficiaries"],
+        apis = ["beneficiaries"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetAccountBeneficiaries_v3_1_9() {
+        GetAccountBeneficiaries(OBVersion.v3_1_9, tppResource).shouldGetAccountBeneficiariesTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/beneficiaries/junit/v3_1_9/GetAccountBeneficiariesTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/beneficiaries/junit/v3_1_9/GetAccountBeneficiariesTest.kt
@@ -12,8 +12,7 @@ class GetAccountBeneficiariesTest(val tppResource: CreateTppCallback.TppResource
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountBeneficiaries"],
-        apis = ["beneficiaries"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["beneficiaries"]
     )
     @Test
     fun shouldGetAccountBeneficiaries_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/beneficiaries/junit/v3_1_9/GetBeneficiariesTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/beneficiaries/junit/v3_1_9/GetBeneficiariesTest.kt
@@ -11,8 +11,7 @@ class GetBeneficiariesTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetBeneficiaries"],
-        apis = ["beneficiaries"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["beneficiaries"]
     )
     @Test
     fun shouldGetBeneficiaries_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/beneficiaries/junit/v3_1_9/GetBeneficiariesTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/beneficiaries/junit/v3_1_9/GetBeneficiariesTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.beneficiaries.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.beneficiaries.api.v3_1_8.GetBeneficiaries
+import org.junit.jupiter.api.Test
+
+class GetBeneficiariesTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetBeneficiaries"],
+        apis = ["beneficiaries"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetBeneficiaries_v3_1_9() {
+        GetBeneficiaries(OBVersion.v3_1_9, tppResource).shouldGetBeneficiariesTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/direct/debits/junit/v3_1_9/GetAccountDirectDebitsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/direct/debits/junit/v3_1_9/GetAccountDirectDebitsTest.kt
@@ -12,8 +12,7 @@ class GetAccountDirectDebitsTest(val tppResource: CreateTppCallback.TppResource)
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccountDirectDebits"],
-        apis = ["direct-debits"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+        apis = ["direct-debits"]
     )
     @Test
     fun shouldGetAccountDirectDebits_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/direct/debits/junit/v3_1_9/GetAccountDirectDebitsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/direct/debits/junit/v3_1_9/GetAccountDirectDebitsTest.kt
@@ -1,0 +1,22 @@
+package com.forgerock.uk.openbanking.tests.functional.account.direct.debits.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.direct.debits.api.v3_1_8.GetAccountDirectDebits
+import org.junit.jupiter.api.Test
+
+class GetAccountDirectDebitsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccountDirectDebits"],
+        apis = ["direct-debits"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+    )
+    @Test
+    fun shouldGetAccountDirectDebits_v3_1_9() {
+        GetAccountDirectDebits(OBVersion.v3_1_9, tppResource).shouldGetAccountDirectDebitsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/direct/debits/junit/v3_1_9/GetDirectDebitsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/direct/debits/junit/v3_1_9/GetDirectDebitsTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.direct.debits.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.direct.debits.api.v3_1_8.GetDirectDebits
+import org.junit.jupiter.api.Test
+
+class GetDirectDebitsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetDirectDebits"],
+        apis = ["direct-debits"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+    )
+    @Test
+    fun shouldGetDirectDebits_v3_1_9() {
+        GetDirectDebits(OBVersion.v3_1_9, tppResource).shouldGetDirectDebitsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/direct/debits/junit/v3_1_9/GetDirectDebitsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/direct/debits/junit/v3_1_9/GetDirectDebitsTest.kt
@@ -11,8 +11,7 @@ class GetDirectDebitsTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetDirectDebits"],
-        apis = ["direct-debits"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+        apis = ["direct-debits"]
     )
     @Test
     fun shouldGetDirectDebits_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/offers/junit/v3_1_9/GetAccountOffersTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/offers/junit/v3_1_9/GetAccountOffersTest.kt
@@ -1,0 +1,22 @@
+package com.forgerock.uk.openbanking.tests.functional.account.offers.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.offers.api.v3_1_8.GetAccountOffers
+import org.junit.jupiter.api.Test
+
+class GetAccountOffersTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountOffers"],
+        apis = ["offers"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+    )
+    @Test
+    fun shouldGetAccountOffers_v3_1_9() {
+        GetAccountOffers(OBVersion.v3_1_9, tppResource).shouldGetAccountOffersTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/offers/junit/v3_1_9/GetAccountOffersTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/offers/junit/v3_1_9/GetAccountOffersTest.kt
@@ -12,8 +12,7 @@ class GetAccountOffersTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountOffers"],
-        apis = ["offers"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+        apis = ["offers"]
     )
     @Test
     fun shouldGetAccountOffers_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/offers/junit/v3_1_9/GetOffersTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/offers/junit/v3_1_9/GetOffersTest.kt
@@ -1,0 +1,22 @@
+package com.forgerock.uk.openbanking.tests.functional.account.offers.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.offers.api.v3_1_8.GetOffers
+import org.junit.jupiter.api.Test
+
+class GetOffersTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetOffers"],
+        apis = ["offers"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+    )
+    @Test
+    fun shouldGetOffers_v3_1_9() {
+        GetOffers(OBVersion.v3_1_9, tppResource).shouldGetOffersTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/offers/junit/v3_1_9/GetOffersTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/offers/junit/v3_1_9/GetOffersTest.kt
@@ -12,8 +12,7 @@ class GetOffersTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetOffers"],
-        apis = ["offers"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+        apis = ["offers"]
     )
     @Test
     fun shouldGetOffers_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/parties/junit/v3_1_9/GetAccountPartiesTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/parties/junit/v3_1_9/GetAccountPartiesTest.kt
@@ -12,8 +12,7 @@ class GetAccountPartiesTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountParties"],
-        apis = ["party"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+        apis = ["party"]
     )
     @Test
     fun shouldGetAccountParties_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/parties/junit/v3_1_9/GetAccountPartiesTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/parties/junit/v3_1_9/GetAccountPartiesTest.kt
@@ -1,0 +1,22 @@
+package com.forgerock.uk.openbanking.tests.functional.account.parties.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.parties.api.v3_1_8.GetAccountParties
+import org.junit.jupiter.api.Test
+
+class GetAccountPartiesTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountParties"],
+        apis = ["party"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+    )
+    @Test
+    fun shouldGetAccountParties_v3_1_9() {
+        GetAccountParties(OBVersion.v3_1_9, tppResource).shouldGetAccountPartiesTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/parties/junit/v3_1_9/GetAccountPartyTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/parties/junit/v3_1_9/GetAccountPartyTest.kt
@@ -1,0 +1,22 @@
+package com.forgerock.uk.openbanking.tests.functional.account.parties.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.parties.api.v3_1_8.GetAccountParty
+import org.junit.jupiter.api.Test
+
+class GetAccountPartyTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountParty"],
+        apis = ["party"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+    )
+    @Test
+    fun shouldGetAccountParty_v3_1_9() {
+        GetAccountParty(OBVersion.v3_1_9, tppResource).shouldGetAccountPartyTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/parties/junit/v3_1_9/GetAccountPartyTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/parties/junit/v3_1_9/GetAccountPartyTest.kt
@@ -12,8 +12,7 @@ class GetAccountPartyTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountParty"],
-        apis = ["party"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+        apis = ["party"]
     )
     @Test
     fun shouldGetAccountParty_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/parties/junit/v3_1_9/GetPartyTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/parties/junit/v3_1_9/GetPartyTest.kt
@@ -11,8 +11,7 @@ class GetPartyTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetParty"],
-        apis = ["party"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+        apis = ["party"]
     )
     @Test
     fun shouldGetParty_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/parties/junit/v3_1_9/GetPartyTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/parties/junit/v3_1_9/GetPartyTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.parties.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.parties.api.v3_1_8.GetParty
+import org.junit.jupiter.api.Test
+
+class GetPartyTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetParty"],
+        apis = ["party"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+    )
+    @Test
+    fun shouldGetParty_v3_1_9() {
+        GetParty(OBVersion.v3_1_9, tppResource).shouldGetPartyTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/products/junit/v3_1_9/GetAccountProductTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/products/junit/v3_1_9/GetAccountProductTest.kt
@@ -1,0 +1,22 @@
+package com.forgerock.uk.openbanking.tests.functional.account.products.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.products.api.v3_1_8.GetAccountProduct
+import org.junit.jupiter.api.Test
+
+class GetAccountProductTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountProduct"],
+        apis = ["products"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+    )
+    @Test
+    fun shouldGetAccountProduct_v3_1_9() {
+        GetAccountProduct(OBVersion.v3_1_9, tppResource).shouldGetAccountProductTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/products/junit/v3_1_9/GetAccountProductTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/products/junit/v3_1_9/GetAccountProductTest.kt
@@ -12,8 +12,7 @@ class GetAccountProductTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountProduct"],
-        apis = ["products"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+        apis = ["products"]
     )
     @Test
     fun shouldGetAccountProduct_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/products/junit/v3_1_9/GetProductsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/products/junit/v3_1_9/GetProductsTest.kt
@@ -11,8 +11,7 @@ class GetProductsTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetProducts"],
-        apis = ["products"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+        apis = ["products"]
     )
     @Test
     fun shouldGetProducts_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/products/junit/v3_1_9/GetProductsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/products/junit/v3_1_9/GetProductsTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.products.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.products.api.v3_1_8.GetProducts
+import org.junit.jupiter.api.Test
+
+class GetProductsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetProducts"],
+        apis = ["products"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+    )
+    @Test
+    fun shouldGetProducts_v3_1_9() {
+        GetProducts(OBVersion.v3_1_9, tppResource).shouldGetProductsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/scheduled/payments/junit/v3_1_9/GetAccountScheduledPaymentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/scheduled/payments/junit/v3_1_9/GetAccountScheduledPaymentsTest.kt
@@ -11,8 +11,7 @@ class GetAccountScheduledPaymentsTest(val tppResource: CreateTppCallback.TppReso
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountScheduledPayments"],
-        apis = ["scheduled-payments"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["scheduled-payments"]
     )
     @Test
     fun shouldGetAccountScheduledPayments_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/scheduled/payments/junit/v3_1_9/GetAccountScheduledPaymentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/scheduled/payments/junit/v3_1_9/GetAccountScheduledPaymentsTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.scheduled.payments.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.scheduled.payments.api.v3_1_8.GetAccountScheduledPayments
+import org.junit.jupiter.api.Test
+
+class GetAccountScheduledPaymentsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountScheduledPayments"],
+        apis = ["scheduled-payments"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetAccountScheduledPayments_v3_1_9() {
+        GetAccountScheduledPayments(OBVersion.v3_1_9, tppResource).shouldGetAccountScheduledPaymentsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/scheduled/payments/junit/v3_1_9/GetScheduledPaymentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/scheduled/payments/junit/v3_1_9/GetScheduledPaymentsTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.scheduled.payments.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.scheduled.payments.api.v3_1_8.GetScheduledPayments
+import org.junit.jupiter.api.Test
+
+class GetScheduledPaymentsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetScheduledPayments"],
+        apis = ["scheduled-payments"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetScheduledPayments_v3_1_9() {
+        GetScheduledPayments(OBVersion.v3_1_9, tppResource).shouldGetScheduledPaymentsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/scheduled/payments/junit/v3_1_9/GetScheduledPaymentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/scheduled/payments/junit/v3_1_9/GetScheduledPaymentsTest.kt
@@ -11,8 +11,7 @@ class GetScheduledPaymentsTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetScheduledPayments"],
-        apis = ["scheduled-payments"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["scheduled-payments"]
     )
     @Test
     fun shouldGetScheduledPayments_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/standing/orders/junit/v3_1_9/GetAccountStandingOrdersTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/standing/orders/junit/v3_1_9/GetAccountStandingOrdersTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.standing.orders.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.standing.orders.api.v3_1_8.GetAccountStandingOrders
+import org.junit.jupiter.api.Test
+
+class GetAccountStandingOrdersTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountStandingOrders"],
+        apis = ["standing-orders"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetAccountStandingOrders_v3_1_9() {
+        GetAccountStandingOrders(OBVersion.v3_1_9, tppResource).shouldGetAccountStandingOrdersTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/standing/orders/junit/v3_1_9/GetAccountStandingOrdersTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/standing/orders/junit/v3_1_9/GetAccountStandingOrdersTest.kt
@@ -11,8 +11,7 @@ class GetAccountStandingOrdersTest(val tppResource: CreateTppCallback.TppResourc
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountStandingOrders"],
-        apis = ["standing-orders"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["standing-orders"]
     )
     @Test
     fun shouldGetAccountStandingOrders_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/standing/orders/junit/v3_1_9/GetStandingOrdersTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/standing/orders/junit/v3_1_9/GetStandingOrdersTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.standing.orders.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.standing.orders.api.v3_1_8.GetStandingOrders
+import org.junit.jupiter.api.Test
+
+class GetStandingOrdersTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetStandingOrders"],
+        apis = ["standing-orders"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetStandingOrders_v3_1_9() {
+        GetStandingOrders(OBVersion.v3_1_9, tppResource).shouldGetStandingOrdersTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/standing/orders/junit/v3_1_9/GetStandingOrdersTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/standing/orders/junit/v3_1_9/GetStandingOrdersTest.kt
@@ -11,8 +11,7 @@ class GetStandingOrdersTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetStandingOrders"],
-        apis = ["standing-orders"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["standing-orders"]
     )
     @Test
     fun shouldGetStandingOrders_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetAccountStatementFileTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetAccountStatementFileTest.kt
@@ -20,8 +20,7 @@ class GetAccountStatementFileTest(val tppResource: CreateTppCallback.TppResource
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountStatementFile"],
-        apis = ["statements"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+        apis = ["statements"]
     )
     @Test
     fun shouldGet_badRequest_StatementFile_v3_1_9() {
@@ -32,8 +31,7 @@ class GetAccountStatementFileTest(val tppResource: CreateTppCallback.TppResource
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountStatementFile"],
-        apis = ["statements"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+        apis = ["statements"]
     )
     @Test
     fun shouldGetStatementFile_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetAccountStatementFileTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetAccountStatementFileTest.kt
@@ -1,0 +1,42 @@
+package com.forgerock.uk.openbanking.tests.functional.account.statements.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.statements.api.v3_1_8.GetAccountStatementFile
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetAccountStatementFileTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getAccountStatementFileApi: GetAccountStatementFile
+
+    @BeforeEach
+    fun setUp() {
+        getAccountStatementFileApi = GetAccountStatementFile(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountStatementFile"],
+        apis = ["statements"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+    )
+    @Test
+    fun shouldGet_badRequest_StatementFile_v3_1_9() {
+        getAccountStatementFileApi.shouldGet_badRequest_StatementFileTest()
+    }
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountStatementFile"],
+        apis = ["statements"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+    )
+    @Test
+    fun shouldGetStatementFile_v3_1_9() {
+        getAccountStatementFileApi.shouldGetStatementFileTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetAccountStatementTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetAccountStatementTest.kt
@@ -11,8 +11,7 @@ class GetAccountStatementTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountStatement"],
-        apis = ["statements"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+        apis = ["statements"]
     )
     @Test
     fun shouldGetAccountStatement_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetAccountStatementTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetAccountStatementTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.statements.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.statements.api.v3_1_8.GetAccountStatement
+import org.junit.jupiter.api.Test
+
+class GetAccountStatementTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountStatement"],
+        apis = ["statements"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+    )
+    @Test
+    fun shouldGetAccountStatement_v3_1_9() {
+        GetAccountStatement(OBVersion.v3_1_9, tppResource).shouldGetAccountStatementTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetAccountStatementTransactionsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetAccountStatementTransactionsTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.statements.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.statements.api.v3_1_8.GetAccountStatementTransactions
+import org.junit.jupiter.api.Test
+
+class GetAccountStatementTransactionsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountStatementTransactions"],
+        apis = ["statements"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+    )
+    @Test
+    fun shouldGetAccountStatementTransactions_v3_1_9() {
+        GetAccountStatementTransactions(OBVersion.v3_1_9, tppResource).shouldGetAccountStatementTransactionsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetAccountStatementTransactionsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetAccountStatementTransactionsTest.kt
@@ -11,8 +11,7 @@ class GetAccountStatementTransactionsTest(val tppResource: CreateTppCallback.Tpp
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountStatementTransactions"],
-        apis = ["statements"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+        apis = ["statements"]
     )
     @Test
     fun shouldGetAccountStatementTransactions_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetAccountStatementsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetAccountStatementsTest.kt
@@ -11,8 +11,7 @@ class GetAccountStatementsTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountStatements"],
-        apis = ["statements"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+        apis = ["statements"]
     )
     @Test
     fun shouldGetAccountStatements_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetAccountStatementsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetAccountStatementsTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.statements.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.statements.api.v3_1_8.GetAccountStatements
+import org.junit.jupiter.api.Test
+
+class GetAccountStatementsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountStatements"],
+        apis = ["statements"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+    )
+    @Test
+    fun shouldGetAccountStatements_v3_1_9() {
+        GetAccountStatements(OBVersion.v3_1_9, tppResource).shouldGetAccountStatementsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetStatementsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetStatementsTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.statements.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.statements.api.v3_1_8.GetStatements
+import org.junit.jupiter.api.Test
+
+class GetStatementsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetStatements"],
+        apis = ["statements"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+    )
+    @Test
+    fun shouldGetStatements_v3_1_9() {
+        GetStatements(OBVersion.v3_1_9, tppResource).shouldGetStatementsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetStatementsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_9/GetStatementsTest.kt
@@ -11,8 +11,7 @@ class GetStatementsTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetStatements"],
-        apis = ["statements"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5", "v.3.1.4", "v.3.1.3"]
+        apis = ["statements"]
     )
     @Test
     fun shouldGetStatements_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/transactions/junit/v3_1_9/GetAccountTransactionsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/transactions/junit/v3_1_9/GetAccountTransactionsTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.transactions.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.transactions.api.v3_1_8.GetAccountTransactions
+import org.junit.jupiter.api.Test
+
+class GetAccountTransactionsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountTransactions"],
+        apis = ["transactions"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetAccountTransactions_v3_1_9() {
+        GetAccountTransactions(OBVersion.v3_1_9, tppResource).shouldGetAccountTransactionsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/transactions/junit/v3_1_9/GetAccountTransactionsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/transactions/junit/v3_1_9/GetAccountTransactionsTest.kt
@@ -11,8 +11,7 @@ class GetAccountTransactionsTest(val tppResource: CreateTppCallback.TppResource)
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountTransactions"],
-        apis = ["transactions"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["transactions"]
     )
     @Test
     fun shouldGetAccountTransactions_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/transactions/junit/v3_1_9/GetTransactionsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/transactions/junit/v3_1_9/GetTransactionsTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.transactions.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.transactions.api.v3_1_8.GetTransactions
+import org.junit.jupiter.api.Test
+
+class GetTransactionsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.9",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetTransactions"],
+        apis = ["transactions"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetTransactions_v3_1_9() {
+        GetTransactions(OBVersion.v3_1_9, tppResource).shouldGetTransactionsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/transactions/junit/v3_1_9/GetTransactionsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/transactions/junit/v3_1_9/GetTransactionsTest.kt
@@ -11,8 +11,7 @@ class GetTransactionsTest(val tppResource: CreateTppCallback.TppResource) {
         type = "accounts",
         apiVersion = "v3.1.9",
         operations = ["CreateAccountAccessConsent", "GetAccounts", "GetTransactions"],
-        apis = ["transactions"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["transactions"]
     )
     @Test
     fun shouldGetTransactions_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_9/CreateDomesticPaymentConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_9/CreateDomesticPaymentConsentsTest.kt
@@ -20,8 +20,7 @@ class CreateDomesticPaymentConsentsTest(val tppResource: CreateTppCallback.TppRe
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticPaymentConsent"],
-        apis = ["domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payment-consents"]
     )
     @Test
     fun createDomesticPaymentsConsents_v3_1_9() {
@@ -32,8 +31,7 @@ class CreateDomesticPaymentConsentsTest(val tppResource: CreateTppCallback.TppRe
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticPaymentConsent"],
-        apis = ["domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticPaymentsConsents_throwsNoDetachedJws_v3_1_9() {
@@ -44,8 +42,7 @@ class CreateDomesticPaymentConsentsTest(val tppResource: CreateTppCallback.TppRe
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticPaymentConsent"],
-        apis = ["domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticPaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
@@ -56,8 +53,7 @@ class CreateDomesticPaymentConsentsTest(val tppResource: CreateTppCallback.TppRe
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticPaymentConsent"],
-        apis = ["domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidFormatDetachedJws_v3_1_9() {
@@ -68,8 +64,7 @@ class CreateDomesticPaymentConsentsTest(val tppResource: CreateTppCallback.TppRe
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticPaymentConsent"],
-        apis = ["domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidKidDetachedJws_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_9/CreateDomesticPaymentConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_9/CreateDomesticPaymentConsentsTest.kt
@@ -1,0 +1,78 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.api.v3_1_8.CreateDomesticPaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateDomesticPaymentConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createDomesticPaymentsConsentsApi: CreateDomesticPaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        createDomesticPaymentsConsentsApi = CreateDomesticPaymentsConsents(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createDomesticPaymentsConsents_v3_1_9() {
+        createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsNoDetachedJws_v3_1_9() {
+        createDomesticPaymentsConsentsApi.shouldCreateDomesticPaymentsConsents_throwsNoDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
+        createDomesticPaymentsConsentsApi.shouldCreateDomesticPaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidFormatDetachedJws_v3_1_9() {
+        createDomesticPaymentsConsentsApi.shouldCreateDomesticPaymentsConsents_throwsSendInvalidFormatDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidKidDetachedJws_v3_1_9() {
+        createDomesticPaymentsConsentsApi.shouldCreateDomesticPaymentsConsents_throwsSendInvalidKidDetachedJwsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_9/GetDomesticPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_9/GetDomesticPaymentsConsentFundsConfirmationTest.kt
@@ -22,8 +22,7 @@ class GetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: CreateTpp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsentsConsentIdFundsConfirmation"],
-        apis = ["domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payment-consents"]
     )
     @Test
     fun shouldGetDomesticPaymentConsentsFundsConfirmation_false_v3_1_9() {
@@ -35,8 +34,7 @@ class GetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: CreateTpp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsentsConsentIdFundsConfirmation"],
-        apis = ["domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payment-consents"]
     )
     @Test
     fun shouldGetDomesticPaymentConsentsFundsConfirmation_throwsWrongGrantType_v3_1_9() {
@@ -47,8 +45,7 @@ class GetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: CreateTpp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsentsConsentIdFundsConfirmation"],
-        apis = ["domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payment-consents"]
     )
     @Test
     fun shouldGetDomesticPaymentConsentsFundsConfirmation_true_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_9/GetDomesticPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_9/GetDomesticPaymentsConsentFundsConfirmationTest.kt
@@ -1,0 +1,57 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.api.v3_1_8.GetDomesticPaymentsConsentFundsConfirmation
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class GetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getDomesticPaymentsConsentFundsConfirmationApi: GetDomesticPaymentsConsentFundsConfirmation
+
+    @BeforeEach
+    fun setUp() {
+        getDomesticPaymentsConsentFundsConfirmationApi =
+            GetDomesticPaymentsConsentFundsConfirmation(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetDomesticPaymentConsentsFundsConfirmation_false_v3_1_9() {
+        getDomesticPaymentsConsentFundsConfirmationApi.shouldGetDomesticPaymentConsentsFundsConfirmation_false()
+    }
+
+    @Disabled("Enhancement: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/337")
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetDomesticPaymentConsentsFundsConfirmation_throwsWrongGrantType_v3_1_9() {
+        getDomesticPaymentsConsentFundsConfirmationApi.shouldGetDomesticPaymentConsentsFundsConfirmation_throwsWrongGrantType()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetDomesticPaymentConsentsFundsConfirmation_true_v3_1_9() {
+        getDomesticPaymentsConsentFundsConfirmationApi.shouldGetDomesticPaymentConsentsFundsConfirmation_true()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_9/GetDomesticPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_9/GetDomesticPaymentsConsentsTest.kt
@@ -20,8 +20,7 @@ class GetDomesticPaymentsConsentsTest(val tppResource: CreateTppCallback.TppReso
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
-        apis = ["domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payment-consents"]
     )
     @Test
     fun shouldGetDomesticPaymentsConsents_v3_1_9() {
@@ -32,8 +31,7 @@ class GetDomesticPaymentsConsentsTest(val tppResource: CreateTppCallback.TppReso
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
-        apis = ["domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payment-consents"]
     )
     @Test
     fun shouldGetDomesticPaymentsConsents_withoutOptionalDebtorAccount_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_9/GetDomesticPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_9/GetDomesticPaymentsConsentsTest.kt
@@ -1,0 +1,42 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.api.v3_1_8.GetDomesticPaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetDomesticPaymentsConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getDomesticPaymentsConsentsApi: GetDomesticPaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        getDomesticPaymentsConsentsApi = GetDomesticPaymentsConsents(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetDomesticPaymentsConsents_v3_1_9() {
+        getDomesticPaymentsConsentsApi.shouldGetDomesticPaymentsConsents()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetDomesticPaymentsConsents_withoutOptionalDebtorAccount_v3_1_9() {
+        getDomesticPaymentsConsentsApi.shouldGetDomesticPaymentsConsents_withoutOptionalDebtorAccountTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/junit/v3_1_9/CreateDomesticPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/junit/v3_1_9/CreateDomesticPaymentTest.kt
@@ -20,8 +20,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
-        apis = ["domestic-payments", "domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payments", "domestic-payment-consents"]
     )
     @Test
     fun createDomesticPayments_v3_1_9() {
@@ -32,8 +31,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
-        apis = ["domestic-payments", "domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payments", "domestic-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticPayments_throwsPaymentAlreadyExists_v3_1_9() {
@@ -44,8 +42,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
-        apis = ["domestic-payments", "domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payments", "domestic-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticPayments_throwsSendInvalidFormatDetachedJws_v3_1_9() {
@@ -56,8 +53,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
-        apis = ["domestic-payments", "domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payments", "domestic-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticPayments_throwsNoDetachedJws_v3_1_9() {
@@ -68,8 +64,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
-        apis = ["domestic-payments", "domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payments", "domestic-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticPayments_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
@@ -80,8 +75,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
-        apis = ["domestic-payments", "domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payments", "domestic-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticPayments_throwsSendInvalidKidDetachedJws_v3_1_9() {
@@ -92,8 +86,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
-        apis = ["domestic-payments", "domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payments", "domestic-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_9() {
@@ -104,8 +97,7 @@ class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) 
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
-        apis = ["domestic-payments", "domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payments", "domestic-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/junit/v3_1_9/CreateDomesticPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/junit/v3_1_9/CreateDomesticPaymentTest.kt
@@ -1,0 +1,114 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.api.v3_1_8.CreateDomesticPayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createDomesticPaymentApi: CreateDomesticPayment
+
+    @BeforeEach
+    fun setUp() {
+        createDomesticPaymentApi = CreateDomesticPayment(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createDomesticPayments_v3_1_9() {
+        createDomesticPaymentApi.createDomesticPaymentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPayments_throwsPaymentAlreadyExists_v3_1_9() {
+        createDomesticPaymentApi.shouldCreateDomesticPayments_throwsPaymentAlreadyExistsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPayments_throwsSendInvalidFormatDetachedJws_v3_1_9() {
+        createDomesticPaymentApi.shouldCreateDomesticPayments_throwsSendInvalidFormatDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPayments_throwsNoDetachedJws_v3_1_9() {
+        createDomesticPaymentApi.shouldCreateDomesticPayments_throwsNoDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPayments_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
+        createDomesticPaymentApi.shouldCreateDomesticPayments_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPayments_throwsSendInvalidKidDetachedJws_v3_1_9() {
+        createDomesticPaymentApi.shouldCreateDomesticPayments_throwsSendInvalidKidDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_9() {
+        createDomesticPaymentApi.shouldCreateDomesticPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBodyTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_9() {
+        createDomesticPaymentApi.shouldCreateDomesticPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/junit/v3_1_9/GetDomesticPaymentDomesticPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/junit/v3_1_9/GetDomesticPaymentDomesticPaymentIdPaymentDetailsTest.kt
@@ -12,8 +12,7 @@ class GetDomesticPaymentDomesticPaymentIdPaymentDetailsTest(val tppResource: Cre
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetDomesticPayment", "CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent", "GetDomesticPaymentDomesticPaymentIdPaymentDetails"],
-        apis = ["domestic-payments", "domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payments", "domestic-payment-consents"]
     )
     @Test
     fun getDomesticPaymentDomesticPaymentIdPaymentDetails_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/junit/v3_1_9/GetDomesticPaymentDomesticPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/junit/v3_1_9/GetDomesticPaymentDomesticPaymentIdPaymentDetailsTest.kt
@@ -1,0 +1,25 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.api.v3_1_8.GetDomesticPaymentDomesticPaymentIdPaymentDetails
+import org.junit.jupiter.api.Test
+
+class GetDomesticPaymentDomesticPaymentIdPaymentDetailsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetDomesticPayment", "CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent", "GetDomesticPaymentDomesticPaymentIdPaymentDetails"],
+        apis = ["domestic-payments", "domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getDomesticPaymentDomesticPaymentIdPaymentDetails_v3_1_9() {
+        GetDomesticPaymentDomesticPaymentIdPaymentDetails(
+            OBVersion.v3_1_9,
+            tppResource
+        ).getDomesticPaymentDomesticPaymentIdPaymentDetailsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/junit/v3_1_9/GetDomesticPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/junit/v3_1_9/GetDomesticPaymentTest.kt
@@ -1,0 +1,44 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.api.v3_1_8.GetDomesticPayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class GetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getDomesticPaymentApi: GetDomesticPayment
+
+    @BeforeEach
+    fun setUp() {
+        getDomesticPaymentApi = GetDomesticPayment(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetDomesticPayment", "CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getDomesticPayments_v3_1_9() {
+        getDomesticPaymentApi.getDomesticPaymentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetDomesticPayment", "CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    @Disabled("Issue to fix this test: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/492")
+    fun shouldGetDomesticPayments_withReadRefund_v3_1_9() {
+        getDomesticPaymentApi.shouldGetDomesticPayments_withReadRefundTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/junit/v3_1_9/GetDomesticPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/junit/v3_1_9/GetDomesticPaymentTest.kt
@@ -21,8 +21,7 @@ class GetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) {
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetDomesticPayment", "CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
-        apis = ["domestic-payments", "domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payments", "domestic-payment-consents"]
     )
     @Test
     fun getDomesticPayments_v3_1_9() {
@@ -33,8 +32,7 @@ class GetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) {
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetDomesticPayment", "CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
-        apis = ["domestic-payments", "domestic-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-payments", "domestic-payment-consents"]
     )
     @Test
     @Disabled("Issue to fix this test: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/492")

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/junit/v3_1_9/CreateDomesticScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/junit/v3_1_9/CreateDomesticScheduledPaymentsConsentsTest.kt
@@ -21,8 +21,7 @@ class CreateDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCall
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticScheduledPaymentConsent"],
-        apis = ["domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payment-consents"]
     )
     @Test
     fun createDomesticScheduledPaymentsConsents_v3_1_9() {
@@ -33,8 +32,7 @@ class CreateDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCall
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticScheduledPaymentConsent"],
-        apis = ["domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticScheduledPaymentsConsents_throwsSendInvalidFormatDetachedJws_v3_1_9() {
@@ -45,8 +43,7 @@ class CreateDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCall
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticScheduledPaymentConsent"],
-        apis = ["domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticScheduledPaymentsConsents_throwsNoDetachedJws_v3_1_9() {
@@ -57,8 +54,7 @@ class CreateDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCall
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticScheduledPaymentConsent"],
-        apis = ["domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticScheduledPaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
@@ -69,8 +65,7 @@ class CreateDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCall
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticScheduledPaymentConsent"],
-        apis = ["domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticScheduledPaymentsConsents_throwsSendInvalidKidDetachedJws_v3_1_9() {
@@ -81,8 +76,7 @@ class CreateDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCall
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticScheduledPaymentConsent"],
-        apis = ["domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticScheduledPaymentsConsents_throwsRequestExecutionTimeInThePast_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/junit/v3_1_9/CreateDomesticScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/junit/v3_1_9/CreateDomesticScheduledPaymentsConsentsTest.kt
@@ -1,0 +1,91 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.consents.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.consents.api.v3_1_8.CreateDomesticScheduledPaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createDomesticScheduledPaymentsConsentsApi: CreateDomesticScheduledPaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        createDomesticScheduledPaymentsConsentsApi =
+            CreateDomesticScheduledPaymentsConsents(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createDomesticScheduledPaymentsConsents_v3_1_9() {
+        createDomesticScheduledPaymentsConsentsApi.createDomesticScheduledPaymentsConsentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPaymentsConsents_throwsSendInvalidFormatDetachedJws_v3_1_9() {
+        createDomesticScheduledPaymentsConsentsApi.shouldCreateDomesticScheduledPaymentsConsents_throwsSendInvalidFormatDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPaymentsConsents_throwsNoDetachedJws_v3_1_9() {
+        createDomesticScheduledPaymentsConsentsApi.shouldCreateDomesticScheduledPaymentsConsents_throwsNoDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
+        createDomesticScheduledPaymentsConsentsApi.shouldCreateDomesticScheduledPaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPaymentsConsents_throwsSendInvalidKidDetachedJws_v3_1_9() {
+        createDomesticScheduledPaymentsConsentsApi.shouldCreateDomesticScheduledPaymentsConsents_throwsSendInvalidKidDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPaymentsConsents_throwsRequestExecutionTimeInThePast_v3_1_9() {
+        createDomesticScheduledPaymentsConsentsApi.shouldCreateDomesticScheduledPaymentsConsents_throwsRequestExecutionTimeInThePastTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/junit/v3_1_9/GetDomesticScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/junit/v3_1_9/GetDomesticScheduledPaymentsConsentsTest.kt
@@ -1,0 +1,42 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.consents.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.consents.api.v3_1_8.GetDomesticScheduledPaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getDomesticScheduledPaymentsConsentsApi: GetDomesticScheduledPaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        getDomesticScheduledPaymentsConsentsApi = GetDomesticScheduledPaymentsConsents(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetDomesticScheduledPaymentsConsents_v3_1_9() {
+        getDomesticScheduledPaymentsConsentsApi.shouldGetDomesticScheduledPaymentsConsentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetDomesticScheduledPaymentsConsents_withoutOptionalDebtorAccount_v3_1_9() {
+        getDomesticScheduledPaymentsConsentsApi.shouldGetDomesticScheduledPaymentsConsents_withoutOptionalDebtorAccountTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/junit/v3_1_9/GetDomesticScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/junit/v3_1_9/GetDomesticScheduledPaymentsConsentsTest.kt
@@ -20,8 +20,7 @@ class GetDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCallbac
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
-        apis = ["domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payment-consents"]
     )
     @Test
     fun shouldGetDomesticScheduledPaymentsConsents_v3_1_9() {
@@ -32,8 +31,7 @@ class GetDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCallbac
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
-        apis = ["domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payment-consents"]
     )
     @Test
     fun shouldGetDomesticScheduledPaymentsConsents_withoutOptionalDebtorAccount_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_9/CreateDomesticScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_9/CreateDomesticScheduledPaymentTest.kt
@@ -1,0 +1,116 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.api.v3_1_8.CreateDomesticScheduledPayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createDomesticScheduledPayment: CreateDomesticScheduledPayment
+
+    @BeforeEach
+    fun setUp() {
+        createDomesticScheduledPayment = CreateDomesticScheduledPayment(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createDomesticScheduledPayments_v3_1_9() {
+        createDomesticScheduledPayment.createDomesticScheduledPaymentsTest()
+    }
+
+    @Disabled("Bug: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/336")
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPayments_throwsPaymentAlreadyExists_v3_1_9() {
+        createDomesticScheduledPayment.shouldCreateDomesticScheduledPayments_throwsPaymentAlreadyExists()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPayments_throwsSendInvalidFormatDetachedJws_v3_1_9() {
+        createDomesticScheduledPayment.shouldCreateDomesticScheduledPayments_throwsSendInvalidFormatDetachedJws()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPayments_throwsNoDetachedJws_v3_1_9() {
+        createDomesticScheduledPayment.shouldCreateDomesticScheduledPayments_throwsNoDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPayments_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
+        createDomesticScheduledPayment.shouldCreateDomesticScheduledPayments_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPayments_throwsSendInvalidKidDetachedJws_v3_1_9() {
+        createDomesticScheduledPayment.shouldCreateDomesticScheduledPayments_throwsSendInvalidKidDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_9() {
+        createDomesticScheduledPayment.shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBodyTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_9() {
+        createDomesticScheduledPayment.shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_9/CreateDomesticScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_9/CreateDomesticScheduledPaymentTest.kt
@@ -21,8 +21,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
-        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
     )
     @Test
     fun createDomesticScheduledPayments_v3_1_9() {
@@ -34,8 +33,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
-        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticScheduledPayments_throwsPaymentAlreadyExists_v3_1_9() {
@@ -46,8 +44,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
-        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticScheduledPayments_throwsSendInvalidFormatDetachedJws_v3_1_9() {
@@ -58,8 +55,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
-        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticScheduledPayments_throwsNoDetachedJws_v3_1_9() {
@@ -70,8 +66,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
-        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticScheduledPayments_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
@@ -82,8 +77,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
-        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticScheduledPayments_throwsSendInvalidKidDetachedJws_v3_1_9() {
@@ -94,8 +88,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
-        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_9() {
@@ -106,8 +99,7 @@ class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppR
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
-        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_9/GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_9/GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest.kt
@@ -12,8 +12,7 @@ class GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest(val tppReso
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetDomesticScheduledPayment", "CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails"],
-        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
     )
     @Test
     fun getDomesticScheduledPaymentDomesticPaymentIdPaymentDetails_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_9/GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_9/GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest.kt
@@ -1,0 +1,26 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.api.v3_1_8.GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails
+import org.junit.jupiter.api.Test
+
+class GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetDomesticScheduledPayment", "CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getDomesticScheduledPaymentDomesticPaymentIdPaymentDetails_v3_1_9() {
+        GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails(
+            OBVersion.v3_1_9,
+            tppResource
+        ).getDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest()
+    }
+
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_9/GetDomesticScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_9/GetDomesticScheduledPaymentTest.kt
@@ -21,8 +21,7 @@ class GetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppReso
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetDomesticScheduledPayment", "CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
-        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
     )
     @Test
     fun getDomesticScheduledPayments_v3_1_9() {
@@ -33,8 +32,7 @@ class GetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppReso
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetDomesticScheduledPayment", "CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
-        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
     )
     @Disabled
     @Test

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_9/GetDomesticScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_9/GetDomesticScheduledPaymentTest.kt
@@ -1,0 +1,44 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.api.v3_1_8.GetDomesticScheduledPayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class GetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getDomesticScheduledPayment: GetDomesticScheduledPayment
+
+    @BeforeEach
+    fun setUp() {
+        getDomesticScheduledPayment = GetDomesticScheduledPayment(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetDomesticScheduledPayment", "CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getDomesticScheduledPayments_v3_1_9() {
+        getDomesticScheduledPayment.getDomesticScheduledPaymentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetDomesticScheduledPayment", "CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Disabled
+    @Test
+    fun shouldGetDomesticScheduledPayments_withReadRefund_v3_1_9() {
+        getDomesticScheduledPayment.shouldGetDomesticScheduledPayments_withReadRefundTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/GetDomesticStandingOrderConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/GetDomesticStandingOrderConsents.kt
@@ -17,7 +17,7 @@ class GetDomesticStandingOrderConsents(val version: OBVersion, val tppResource: 
 
     private val createDomesticStandingOrderConsentsApi = CreateDomesticStandingOrderConsents(version, tppResource)
 
-    fun shouldGetDomesticStandingOrdersConsents_v3_1_8() {
+    fun shouldGetDomesticStandingOrdersConsents_Test() {
         // Given
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/junit/v3_1_9/CreateDomesticStandingOrderConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/junit/v3_1_9/CreateDomesticStandingOrderConsentsTest.kt
@@ -1,0 +1,102 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.consents.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.consents.api.v3_1_8.CreateDomesticStandingOrderConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createDomesticStandingOrderConsents: CreateDomesticStandingOrderConsents
+
+    @BeforeEach
+    fun setUp() {
+        createDomesticStandingOrderConsents = CreateDomesticStandingOrderConsents(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createDomesticStandingOrdersConsents_v3_1_9() {
+        createDomesticStandingOrderConsents.createDomesticStandingOrdersConsentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createDomesticStandingOrdersConsents_mandatoryFields_v3_1_9() {
+        createDomesticStandingOrderConsents.createDomesticStandingOrdersConsents_mandatoryFields()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsInvalidFrequencyValue_v3_1_9() {
+        createDomesticStandingOrderConsents.shouldCreateDomesticStandingOrdersConsents_throwsInvalidFrequencyValue()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidFormatDetachedJws_v3_1_9() {
+        createDomesticStandingOrderConsents.shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidFormatDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsNoDetachedJws_v3_1_9() {
+        createDomesticStandingOrderConsents.shouldCreateDomesticStandingOrdersConsents_throwsNoDetachedJws()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
+        createDomesticStandingOrderConsents.shouldCreateDomesticStandingOrdersConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidKidDetachedJws_v3_1_9() {
+        createDomesticStandingOrderConsents.shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidKidDetachedJwsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/junit/v3_1_9/CreateDomesticStandingOrderConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/junit/v3_1_9/CreateDomesticStandingOrderConsentsTest.kt
@@ -20,8 +20,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-order-consents"]
     )
     @Test
     fun createDomesticStandingOrdersConsents_v3_1_9() {
@@ -32,8 +31,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-order-consents"]
     )
     @Test
     fun createDomesticStandingOrdersConsents_mandatoryFields_v3_1_9() {
@@ -44,8 +42,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-order-consents"]
     )
     @Test
     fun shouldCreateDomesticStandingOrdersConsents_throwsInvalidFrequencyValue_v3_1_9() {
@@ -56,8 +53,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-order-consents"]
     )
     @Test
     fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidFormatDetachedJws_v3_1_9() {
@@ -68,8 +64,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-order-consents"]
     )
     @Test
     fun shouldCreateDomesticStandingOrdersConsents_throwsNoDetachedJws_v3_1_9() {
@@ -80,8 +75,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-order-consents"]
     )
     @Test
     fun shouldCreateDomesticStandingOrdersConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
@@ -92,8 +86,7 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-order-consents"]
     )
     @Test
     fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidKidDetachedJws_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/junit/v3_1_9/GetDomesticStandingOrderConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/junit/v3_1_9/GetDomesticStandingOrderConsentsTest.kt
@@ -20,8 +20,7 @@ class GetDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback.Tp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
     fun createDomesticStandingOrder_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/junit/v3_1_9/GetDomesticStandingOrderConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/junit/v3_1_9/GetDomesticStandingOrderConsentsTest.kt
@@ -1,4 +1,4 @@
-package com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.consents.junit.v3_1_8
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.consents.junit.v3_1_9
 
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
@@ -13,19 +13,18 @@ class GetDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback.Tp
 
     @BeforeEach
     fun setUp() {
-        getDomesticStandingOrderConsents = GetDomesticStandingOrderConsents(OBVersion.v3_1_8, tppResource)
+        getDomesticStandingOrderConsents = GetDomesticStandingOrderConsents(OBVersion.v3_1_9, tppResource)
     }
 
     @EnabledIfVersion(
         type = "payments",
-        apiVersion = "v3.1.8",
+        apiVersion = "v3.1.9",
         operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
         apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
         compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
     )
     @Test
-    fun createDomesticStandingOrder_v3_1_8() {
+    fun createDomesticStandingOrder_v3_1_9() {
         getDomesticStandingOrderConsents.shouldGetDomesticStandingOrdersConsents_Test()
     }
-
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/junit/v3_1_9/CreateDomesticStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/junit/v3_1_9/CreateDomesticStandingOrderTest.kt
@@ -1,0 +1,128 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.api.v3_1_8.CreateDomesticStandingOrder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createDomesticStandingOrder: CreateDomesticStandingOrder
+
+    @BeforeEach
+    fun setUp() {
+        createDomesticStandingOrder = CreateDomesticStandingOrder(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createDomesticStandingOrder_v3_1_9() {
+        createDomesticStandingOrder.createDomesticStandingOrderTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createDomesticStandingOrder_mandatoryFields_v3_1_9() {
+        createDomesticStandingOrder.createDomesticStandingOrder_mandatoryFieldsTest()
+    }
+
+    @Disabled("Bug: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/336")
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrder_throwsStandingOrderAlreadyExists_v3_1_9() {
+        createDomesticStandingOrder.shouldCreateDomesticStandingOrder_throwsStandingOrderAlreadyExistsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrder_throwsSendInvalidFormatDetachedJws_v3_1_9() {
+        createDomesticStandingOrder.shouldCreateDomesticStandingOrder_throwsSendInvalidFormatDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrder_throwsNoDetachedJws_v3_1_9() {
+        createDomesticStandingOrder.shouldCreateDomesticStandingOrder_throwsNoDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrder_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
+        createDomesticStandingOrder.shouldCreateDomesticStandingOrder_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrder_throwsSendInvalidKidDetachedJws_v3_1_9() {
+        createDomesticStandingOrder.shouldCreateDomesticStandingOrder_throwsSendInvalidKidDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_9() {
+        createDomesticStandingOrder.shouldCreateDomesticStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBodyTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_9() {
+        createDomesticStandingOrder.shouldCreateDomesticStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/junit/v3_1_9/CreateDomesticStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/junit/v3_1_9/CreateDomesticStandingOrderTest.kt
@@ -21,8 +21,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
     fun createDomesticStandingOrder_v3_1_9() {
@@ -33,8 +32,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
     fun createDomesticStandingOrder_mandatoryFields_v3_1_9() {
@@ -46,8 +44,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
     fun shouldCreateDomesticStandingOrder_throwsStandingOrderAlreadyExists_v3_1_9() {
@@ -58,8 +55,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
     fun shouldCreateDomesticStandingOrder_throwsSendInvalidFormatDetachedJws_v3_1_9() {
@@ -70,8 +66,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
     fun shouldCreateDomesticStandingOrder_throwsNoDetachedJws_v3_1_9() {
@@ -82,8 +77,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
     fun shouldCreateDomesticStandingOrder_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
@@ -94,8 +88,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
     fun shouldCreateDomesticStandingOrder_throwsSendInvalidKidDetachedJws_v3_1_9() {
@@ -106,8 +99,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
     fun shouldCreateDomesticStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_9() {
@@ -118,8 +110,7 @@ class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppReso
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
     fun shouldCreateDomesticStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/junit/v3_1_9/GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/junit/v3_1_9/GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest.kt
@@ -21,8 +21,7 @@ class GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest(val tppR
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetDomesticStandingOrder", "CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent", "GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails"],
-        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
     fun getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails_v3_1_9() {
@@ -33,8 +32,7 @@ class GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest(val tppR
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetDomesticStandingOrder", "CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent", "GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails"],
-        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
     fun getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails_v3_1_9_mandatoryFields() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/junit/v3_1_9/GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/junit/v3_1_9/GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest.kt
@@ -1,0 +1,43 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.api.v3_1_8.GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails: GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails
+
+    @BeforeEach
+    fun setUp() {
+        getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails =
+            GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetDomesticStandingOrder", "CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent", "GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails_v3_1_9() {
+        getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails.getDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetDomesticStandingOrder", "CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent", "GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails_v3_1_9_mandatoryFields() {
+        getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails.getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails_mandatoryFieldsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/junit/v3_1_9/GetDomesticStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/junit/v3_1_9/GetDomesticStandingOrderTest.kt
@@ -1,0 +1,57 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.api.v3_1_8.GetDomesticStandingOrder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class GetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getDomesticStandingOrder: GetDomesticStandingOrder
+
+    @BeforeEach
+    fun setUp() {
+        getDomesticStandingOrder = GetDomesticStandingOrder(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetDomesticStandingOrder", "CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getDomesticStandingOrders_v3_1_9() {
+        getDomesticStandingOrder.getDomesticStandingOrdersTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetDomesticStandingOrder", "CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getDomesticStandingOrders_v3_1_9_mandatoryFields() {
+        getDomesticStandingOrder.getDomesticStandingOrders_mandatoryFieldsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetDomesticStandingOrder", "CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Disabled
+    @Test
+    fun shouldGetDomesticStandingOrders_withReadRefund_v3_1_9() {
+        getDomesticStandingOrder.shouldGetDomesticStandingOrders_withReadRefundTest()
+    }
+
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/junit/v3_1_9/GetDomesticStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/junit/v3_1_9/GetDomesticStandingOrderTest.kt
@@ -21,8 +21,7 @@ class GetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppResourc
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetDomesticStandingOrder", "CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
     fun getDomesticStandingOrders_v3_1_9() {
@@ -33,8 +32,7 @@ class GetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppResourc
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetDomesticStandingOrder", "CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Test
     fun getDomesticStandingOrders_v3_1_9_mandatoryFields() {
@@ -45,8 +43,7 @@ class GetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppResourc
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetDomesticStandingOrder", "CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
-        apis = ["domestic-standing-orders", "domestic-standing-order-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
     )
     @Disabled
     @Test

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_9/CreateInternationalPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_9/CreateInternationalPaymentsConsentsTest.kt
@@ -20,8 +20,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPaymentConsent"],
-        apis = ["international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payment-consents"]
     )
     @Test
     fun createInternationalPaymentsConsents_v3_1_9() {
@@ -32,8 +31,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPaymentConsent"],
-        apis = ["international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payment-consents"]
     )
     @Test
     fun createInternationalPaymentsConsents_mandatoryFields_v3_1_9() {
@@ -44,8 +42,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPaymentConsent"],
-        apis = ["international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalPaymentConsents_throwsSendInvalidFormatDetachedJws_v3_1_9() {
@@ -56,8 +53,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPaymentConsent"],
-        apis = ["international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalPaymentConsents_throwsNoDetachedJws_v3_1_9() {
@@ -68,8 +64,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPaymentConsent"],
-        apis = ["international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalPaymentConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
@@ -80,8 +75,7 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPaymentConsent"],
-        apis = ["international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalPaymentConsents_throwsSendInvalidKidDetachedJws_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_9/CreateInternationalPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_9/CreateInternationalPaymentsConsentsTest.kt
@@ -1,0 +1,90 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.api.v3_1_8.CreateInternationalPaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createInternationalPaymentsConsents: CreateInternationalPaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        createInternationalPaymentsConsents = CreateInternationalPaymentsConsents(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPaymentConsent"],
+        apis = ["international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createInternationalPaymentsConsents_v3_1_9() {
+        createInternationalPaymentsConsents.createInternationalPaymentsConsents()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPaymentConsent"],
+        apis = ["international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createInternationalPaymentsConsents_mandatoryFields_v3_1_9() {
+        createInternationalPaymentsConsents.createInternationalPaymentsConsents_mandatoryFieldsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPaymentConsent"],
+        apis = ["international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalPaymentConsents_throwsSendInvalidFormatDetachedJws_v3_1_9() {
+        createInternationalPaymentsConsents.shouldCreateInternationalPaymentConsents_throwsSendInvalidFormatDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPaymentConsent"],
+        apis = ["international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalPaymentConsents_throwsNoDetachedJws_v3_1_9() {
+        createInternationalPaymentsConsents.shouldCreateInternationalPaymentConsents_throwsNoDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPaymentConsent"],
+        apis = ["international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalPaymentConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
+        createInternationalPaymentsConsents.shouldCreateInternationalPaymentConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPaymentConsent"],
+        apis = ["international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalPaymentConsents_throwsSendInvalidKidDetachedJws_v3_1_9() {
+        createInternationalPaymentsConsents.shouldCreateInternationalPaymentConsents_throwsSendInvalidKidDetachedJwsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_9/GetInternationalPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_9/GetInternationalPaymentsConsentFundsConfirmationTest.kt
@@ -1,0 +1,118 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.api.v3_1_8.GetInternationalPaymentsConsentFundsConfirmation
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+@Disabled("Not implemented")
+class GetInternationalPaymentsConsentFundsConfirmationTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getInternationalPaymentsConsentFundsConfirmation: GetInternationalPaymentsConsentFundsConfirmation
+
+    @BeforeEach
+    fun setUp() {
+        getInternationalPaymentsConsentFundsConfirmation =
+            GetInternationalPaymentsConsentFundsConfirmation(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentConsentsFundsConfirmation_true_rateType_AGREED_v3_1_9() {
+        getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_true_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentConsentsFundsConfirmation_true_rateType_ACTUAL_v3_1_9() {
+        getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_true_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentConsentsFundsConfirmation_true_rateType_INDICATIVE_v3_1_9() {
+        getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_true_rateType_INDICATIVE_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentConsentsFundsConfirmation_false_rateType_AGREED_v3_1_9() {
+        getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_false_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentConsentsFundsConfirmation_false_rateType_ACTUAL_v3_1_9() {
+        getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_false_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentConsentsFundsConfirmation_false_rateType_INDICATIVE_v3_1_9() {
+        getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_false_rateType_INDICATIVE_Test()
+    }
+
+    @Disabled("Enhancement: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/337")
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentConsentsFundsConfirmation_throwsWrongGrantType_v3_1_9() {
+        getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_throwsWrongGrantType_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_v3_1_9() {
+        getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_9/GetInternationalPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_9/GetInternationalPaymentsConsentFundsConfirmationTest.kt
@@ -23,8 +23,7 @@ class GetInternationalPaymentsConsentFundsConfirmationTest(val tppResource: Crea
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
-        apis = ["international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payment-consents"]
     )
     @Test
     fun shouldGetInternationalPaymentConsentsFundsConfirmation_true_rateType_AGREED_v3_1_9() {
@@ -35,8 +34,7 @@ class GetInternationalPaymentsConsentFundsConfirmationTest(val tppResource: Crea
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
-        apis = ["international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payment-consents"]
     )
     @Test
     fun shouldGetInternationalPaymentConsentsFundsConfirmation_true_rateType_ACTUAL_v3_1_9() {
@@ -47,8 +45,7 @@ class GetInternationalPaymentsConsentFundsConfirmationTest(val tppResource: Crea
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
-        apis = ["international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payment-consents"]
     )
     @Test
     fun shouldGetInternationalPaymentConsentsFundsConfirmation_true_rateType_INDICATIVE_v3_1_9() {
@@ -59,8 +56,7 @@ class GetInternationalPaymentsConsentFundsConfirmationTest(val tppResource: Crea
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
-        apis = ["international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payment-consents"]
     )
     @Test
     fun shouldGetInternationalPaymentConsentsFundsConfirmation_false_rateType_AGREED_v3_1_9() {
@@ -71,8 +67,7 @@ class GetInternationalPaymentsConsentFundsConfirmationTest(val tppResource: Crea
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
-        apis = ["international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payment-consents"]
     )
     @Test
     fun shouldGetInternationalPaymentConsentsFundsConfirmation_false_rateType_ACTUAL_v3_1_9() {
@@ -83,8 +78,7 @@ class GetInternationalPaymentsConsentFundsConfirmationTest(val tppResource: Crea
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
-        apis = ["international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payment-consents"]
     )
     @Test
     fun shouldGetInternationalPaymentConsentsFundsConfirmation_false_rateType_INDICATIVE_v3_1_9() {
@@ -96,8 +90,7 @@ class GetInternationalPaymentsConsentFundsConfirmationTest(val tppResource: Crea
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
-        apis = ["international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payment-consents"]
     )
     @Test
     fun shouldGetInternationalPaymentConsentsFundsConfirmation_throwsWrongGrantType_v3_1_9() {
@@ -108,8 +101,7 @@ class GetInternationalPaymentsConsentFundsConfirmationTest(val tppResource: Crea
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
-        apis = ["international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payment-consents"]
     )
     @Test
     fun shouldGetInternationalPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_9/GetInternationalPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_9/GetInternationalPaymentsConsentsTest.kt
@@ -1,0 +1,54 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.api.v3_1_8.GetInternationalPaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getInternationalPaymentsConsents: GetInternationalPaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        getInternationalPaymentsConsents = GetInternationalPaymentsConsents(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentsConsents_rateType_AGREED_v3_1_9() {
+        getInternationalPaymentsConsents.shouldGetInternationalPaymentsConsents_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentsConsents_rateType_ACTUAL_v3_1_9() {
+        getInternationalPaymentsConsents.shouldGetInternationalPaymentsConsents_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentsConsents_rateType_INDICATIVE_v3_1_9() {
+        getInternationalPaymentsConsents.shouldGetInternationalPaymentsConsents_rateType_INDICATIVE_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_9/GetInternationalPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_9/GetInternationalPaymentsConsentsTest.kt
@@ -20,8 +20,7 @@ class GetInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.Tp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payment-consents"]
     )
     @Test
     fun shouldGetInternationalPaymentsConsents_rateType_AGREED_v3_1_9() {
@@ -32,8 +31,7 @@ class GetInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.Tp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payment-consents"]
     )
     @Test
     fun shouldGetInternationalPaymentsConsents_rateType_ACTUAL_v3_1_9() {
@@ -44,8 +42,7 @@ class GetInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.Tp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payment-consents"]
     )
     @Test
     fun shouldGetInternationalPaymentsConsents_rateType_INDICATIVE_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/junit/v3_1_9/CreateInternationalPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/junit/v3_1_9/CreateInternationalPaymentTest.kt
@@ -1,0 +1,150 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.payments.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.api.v3_1_8.CreateInternationalPayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createInternationalPayment: CreateInternationalPayment
+
+    @BeforeEach
+    fun setUp() {
+        createInternationalPayment = CreateInternationalPayment(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createInternationalPayment_rateType_AGREED_v3_1_9() {
+        createInternationalPayment.createInternationalPayment_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createInternationalPayment_rateType_ACTUAL_v3_1_9() {
+        createInternationalPayment.createInternationalPayment_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createInternationalPayment_rateType_INDICATIVE_v3_1_9() {
+        createInternationalPayment.createInternationalPayment_rateType_INDICATIVE_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createInternationalPayment_mandatoryFields_v3_1_9() {
+        createInternationalPayment.createInternationalPayment_mandatoryFields_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalPayment_throwsInternationalPaymentAlreadyExists_v3_1_9() {
+        createInternationalPayment.shouldCreateInternationalPayment_throwsInternationalPaymentAlreadyExists_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalPayment_throwsSendInvalidFormatDetachedJws_v3_1_9() {
+        createInternationalPayment.shouldCreateInternationalPayment_throwsSendInvalidFormatDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalPayment_throwsNoDetachedJws_v3_1_9() {
+        createInternationalPayment.shouldCreateInternationalPayment_throwsNoDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalPayment_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
+        createInternationalPayment.shouldCreateInternationalPayment_throwsNotPermittedB64HeaderAddedInTheDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalPayment_throwsSendInvalidKidDetachedJws_v3_1_9() {
+        createInternationalPayment.shouldCreateInternationalPayment_throwsSendInvalidKidDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_9() {
+        createInternationalPayment.shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_9() {
+        createInternationalPayment.shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/junit/v3_1_9/CreateInternationalPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/junit/v3_1_9/CreateInternationalPaymentTest.kt
@@ -20,8 +20,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun createInternationalPayment_rateType_AGREED_v3_1_9() {
@@ -32,8 +31,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun createInternationalPayment_rateType_ACTUAL_v3_1_9() {
@@ -44,8 +42,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun createInternationalPayment_rateType_INDICATIVE_v3_1_9() {
@@ -56,8 +53,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun createInternationalPayment_mandatoryFields_v3_1_9() {
@@ -68,8 +64,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalPayment_throwsInternationalPaymentAlreadyExists_v3_1_9() {
@@ -80,8 +75,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalPayment_throwsSendInvalidFormatDetachedJws_v3_1_9() {
@@ -92,8 +86,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalPayment_throwsNoDetachedJws_v3_1_9() {
@@ -104,8 +97,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalPayment_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
@@ -116,8 +108,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalPayment_throwsSendInvalidKidDetachedJws_v3_1_9() {
@@ -128,8 +119,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_9() {
@@ -140,8 +130,7 @@ class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResou
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/junit/v3_1_9/GetInternationalPaymentInternationalPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/junit/v3_1_9/GetInternationalPaymentInternationalPaymentIdPaymentDetailsTest.kt
@@ -1,0 +1,67 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.payments.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.api.v3_1_8.GetInternationalPaymentInternationalPaymentIdPaymentDetails
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getInternationalPaymentInternationalPaymentIdPaymentDetails: GetInternationalPaymentInternationalPaymentIdPaymentDetails
+
+    @BeforeEach
+    fun setUp() {
+        getInternationalPaymentInternationalPaymentIdPaymentDetails =
+            GetInternationalPaymentInternationalPaymentIdPaymentDetails(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent", "GetInternationalPaymentInternationalPaymentIdPaymentDetails"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_AGREED_v3_1_9() {
+        getInternationalPaymentInternationalPaymentIdPaymentDetails.getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent", "GetInternationalPaymentInternationalPaymentIdPaymentDetails"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_ACTUAL_v3_1_9() {
+        getInternationalPaymentInternationalPaymentIdPaymentDetails.getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent", "GetInternationalPaymentInternationalPaymentIdPaymentDetails"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_INDICATIVE_v3_1_9() {
+        getInternationalPaymentInternationalPaymentIdPaymentDetails.getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_INDICATIVE_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent", "GetInternationalPaymentInternationalPaymentIdPaymentDetails"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getInternationalPaymentInternationalPaymentIdPaymentDetails_v3_1_9_mandatoryFields() {
+        getInternationalPaymentInternationalPaymentIdPaymentDetails.getInternationalPaymentInternationalPaymentIdPaymentDetails_mandatoryFields_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/junit/v3_1_9/GetInternationalPaymentInternationalPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/junit/v3_1_9/GetInternationalPaymentInternationalPaymentIdPaymentDetailsTest.kt
@@ -21,8 +21,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val tppRes
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent", "GetInternationalPaymentInternationalPaymentIdPaymentDetails"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_AGREED_v3_1_9() {
@@ -33,8 +32,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val tppRes
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent", "GetInternationalPaymentInternationalPaymentIdPaymentDetails"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_ACTUAL_v3_1_9() {
@@ -45,8 +43,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val tppRes
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent", "GetInternationalPaymentInternationalPaymentIdPaymentDetails"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_INDICATIVE_v3_1_9() {
@@ -57,8 +54,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val tppRes
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent", "GetInternationalPaymentInternationalPaymentIdPaymentDetails"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun getInternationalPaymentInternationalPaymentIdPaymentDetails_v3_1_9_mandatoryFields() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/junit/v3_1_9/GetInternationalPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/junit/v3_1_9/GetInternationalPaymentTest.kt
@@ -21,8 +21,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun getInternationalPayments_rateType_AGREED_v3_1_9() {
@@ -33,8 +32,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun getInternationalPayments_rateType_ACTUAL_v3_1_9() {
@@ -45,8 +43,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun getInternationalPayments_rateType_INDICATIVE_v3_1_9() {
@@ -57,8 +54,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun getInternationalPayments_v3_1_9_mandatoryFields() {
@@ -69,8 +65,7 @@ class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Disabled
     @Test

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/junit/v3_1_9/GetInternationalPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/junit/v3_1_9/GetInternationalPaymentTest.kt
@@ -1,0 +1,80 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.payments.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.api.v3_1_8.GetInternationalPayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getInternationalPayment: GetInternationalPayment
+
+    @BeforeEach
+    fun setUp() {
+        getInternationalPayment = GetInternationalPayment(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getInternationalPayments_rateType_AGREED_v3_1_9() {
+        getInternationalPayment.getInternationalPayments_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getInternationalPayments_rateType_ACTUAL_v3_1_9() {
+        getInternationalPayment.getInternationalPayments_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getInternationalPayments_rateType_INDICATIVE_v3_1_9() {
+        getInternationalPayment.getInternationalPayments_rateType_INDICATIVE_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getInternationalPayments_v3_1_9_mandatoryFields() {
+        getInternationalPayment.getInternationalPayments_mandatoryFields_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Disabled
+    @Test
+    fun shouldGetInternationalPayments_withReadRefund_v3_1_9() {
+        getInternationalPayment.shouldGetInternationalPayments_withReadRefund_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails.kt
@@ -266,7 +266,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         assertThat(result.data.paymentStatus).isNotNull()
     }
 
-    fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_v3_1_8_Test() {
+    fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_Test() {
         // Given
         val consentRequest =
             OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5MandatoryFields()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_9/CreateInternationalScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_9/CreateInternationalScheduledPaymentsConsentsTest.kt
@@ -1,0 +1,103 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.consents.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.consents.api.v3_1_8.CreateInternationalScheduledPaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createInternationalScheduledPaymentsConsents: CreateInternationalScheduledPaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        createInternationalScheduledPaymentsConsents =
+            CreateInternationalScheduledPaymentsConsents(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createInternationalScheduledPaymentsConsents_v3_1_9() {
+        createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentsConsentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createInternationalScheduledPaymentsConsents_mandatoryFields_v3_1_9() {
+        createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentsConsents_mandatoryFields_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPaymentConsents_throwsSendInvalidFormatDetachedJws_v3_1_9() {
+        createInternationalScheduledPaymentsConsents.shouldCreateInternationalScheduledPaymentConsents_throwsSendInvalidFormatDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPaymentConsents_throwsNoDetachedJws_v3_1_9() {
+        createInternationalScheduledPaymentsConsents.shouldCreateInternationalScheduledPaymentConsents_throwsNoDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPaymentConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
+        createInternationalScheduledPaymentsConsents.shouldCreateInternationalScheduledPaymentConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPaymentConsents_throwsSendInvalidKidDetachedJws_v3_1_9() {
+        createInternationalScheduledPaymentsConsents.shouldCreateInternationalScheduledPaymentConsents_throwsSendInvalidKidDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPaymentConsents_throwsRequestExecutionTimeInThePast_v3_1_9() {
+        createInternationalScheduledPaymentsConsents.shouldCreateInternationalScheduledPaymentConsents_throwsRequestExecutionTimeInThePast_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_9/CreateInternationalScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_9/CreateInternationalScheduledPaymentsConsentsTest.kt
@@ -21,8 +21,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payment-consents"]
     )
     @Test
     fun createInternationalScheduledPaymentsConsents_v3_1_9() {
@@ -33,8 +32,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payment-consents"]
     )
     @Test
     fun createInternationalScheduledPaymentsConsents_mandatoryFields_v3_1_9() {
@@ -45,8 +43,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalScheduledPaymentConsents_throwsSendInvalidFormatDetachedJws_v3_1_9() {
@@ -57,8 +54,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalScheduledPaymentConsents_throwsNoDetachedJws_v3_1_9() {
@@ -69,8 +65,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalScheduledPaymentConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
@@ -81,8 +76,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalScheduledPaymentConsents_throwsSendInvalidKidDetachedJws_v3_1_9() {
@@ -93,8 +87,7 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalScheduledPaymentConsents_throwsRequestExecutionTimeInThePast_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_9/GetInternationalScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_9/GetInternationalScheduledPaymentsConsentsTest.kt
@@ -21,8 +21,7 @@ class GetInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCa
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payment-consents"]
     )
     @Test
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_AGREED_v3_1_9() {
@@ -33,8 +32,7 @@ class GetInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCa
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payment-consents"]
     )
     @Test
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_ACTUAL_v3_1_9() {
@@ -45,8 +43,7 @@ class GetInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCa
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payment-consents"]
     )
     @Test
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_INDICATIVE_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_9/GetInternationalScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_9/GetInternationalScheduledPaymentsConsentsTest.kt
@@ -1,0 +1,55 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.consents.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.consents.api.v3_1_8.GetInternationalScheduledPaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getInternationalScheduledPaymentsConsentsTest: GetInternationalScheduledPaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        getInternationalScheduledPaymentsConsentsTest =
+            GetInternationalScheduledPaymentsConsents(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetInternationalScheduledPaymentsConsents_rateType_AGREED_v3_1_9() {
+        getInternationalScheduledPaymentsConsentsTest.shouldGetInternationalScheduledPaymentsConsents_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetInternationalScheduledPaymentsConsents_rateType_ACTUAL_v3_1_9() {
+        getInternationalScheduledPaymentsConsentsTest.shouldGetInternationalScheduledPaymentsConsents_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetInternationalScheduledPaymentsConsents_rateType_INDICATIVE_v3_1_9() {
+        getInternationalScheduledPaymentsConsentsTest.shouldGetInternationalScheduledPaymentsConsents_rateType_INDICATIVE_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/junit/v3_1_9/CreateInternationalScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/junit/v3_1_9/CreateInternationalScheduledPaymentTest.kt
@@ -21,8 +21,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
     fun createInternationalScheduledPayment_rateType_AGREED_v3_1_9() {
@@ -33,8 +32,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
     fun createInternationalScheduledPayment_rateType_ACTUAL_v3_1_9() {
@@ -45,8 +43,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
     fun createInternationalScheduledPayment_rateType_INDICATIVE_v3_1_9() {
@@ -57,8 +54,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
     fun createInternationalScheduledPayment_mandatoryFields_v3_1_9() {
@@ -70,8 +66,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalScheduledPayment_throwsInternationalScheduledPaymentAlreadyExists_v3_1_9() {
@@ -82,8 +77,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalScheduledPayment_throwsSendInvalidFormatDetachedJws_v3_1_9() {
@@ -94,8 +88,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalScheduledPayment_throwsNoDetachedJws_v3_1_9() {
@@ -106,8 +99,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalScheduledPayment_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
@@ -118,8 +110,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalScheduledPayment_throwsSendInvalidKidDetachedJws_v3_1_9() {
@@ -130,8 +121,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_9() {
@@ -142,8 +132,7 @@ class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
     fun shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_9() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/junit/v3_1_9/CreateInternationalScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/junit/v3_1_9/CreateInternationalScheduledPaymentTest.kt
@@ -1,0 +1,152 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.api.v3_1_8.CreateInternationalScheduledPayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createInternationalScheduledPayment: CreateInternationalScheduledPayment
+
+    @BeforeEach
+    fun setUp() {
+        createInternationalScheduledPayment = CreateInternationalScheduledPayment(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createInternationalScheduledPayment_rateType_AGREED_v3_1_9() {
+        createInternationalScheduledPayment.createInternationalScheduledPayment_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createInternationalScheduledPayment_rateType_ACTUAL_v3_1_9() {
+        createInternationalScheduledPayment.createInternationalScheduledPayment_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createInternationalScheduledPayment_rateType_INDICATIVE_v3_1_9() {
+        createInternationalScheduledPayment.createInternationalScheduledPayment_rateType_INDICATIVE_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createInternationalScheduledPayment_mandatoryFields_v3_1_9() {
+        createInternationalScheduledPayment.createInternationalScheduledPayment_mandatoryFields_Test()
+    }
+
+    @Disabled("Bug: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/336")
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPayment_throwsInternationalScheduledPaymentAlreadyExists_v3_1_9() {
+        createInternationalScheduledPayment.shouldCreateInternationalScheduledPayment_throwsInternationalScheduledPaymentAlreadyExists_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPayment_throwsSendInvalidFormatDetachedJws_v3_1_9() {
+        createInternationalScheduledPayment.shouldCreateInternationalScheduledPayment_throwsSendInvalidFormatDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPayment_throwsNoDetachedJws_v3_1_9() {
+        createInternationalScheduledPayment.shouldCreateInternationalScheduledPayment_throwsNoDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPayment_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
+        createInternationalScheduledPayment.shouldCreateInternationalScheduledPayment_throwsNotPermittedB64HeaderAddedInTheDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPayment_throwsSendInvalidKidDetachedJws_v3_1_9() {
+        createInternationalScheduledPayment.shouldCreateInternationalScheduledPayment_throwsSendInvalidKidDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_9() {
+        createInternationalScheduledPayment.shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_9() {
+        createInternationalScheduledPayment.shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/junit/v3_1_9/GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/junit/v3_1_9/GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetailsTest.kt
@@ -21,8 +21,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_AGREED_v3_1_9() {
@@ -33,8 +32,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_ACTUAL_v3_1_9() {
@@ -45,8 +43,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_INDICATIVE_v3_1_9() {
@@ -57,8 +54,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails"],
-        apis = ["international-payments", "international-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-payments", "international-payment-consents"]
     )
     @Test
     fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_v3_1_9_mandatoryFields() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/junit/v3_1_9/GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/junit/v3_1_9/GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetailsTest.kt
@@ -1,4 +1,4 @@
-package com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.junit.v3_1_8
+package com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.junit.v3_1_9
 
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
@@ -14,54 +14,54 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
     @BeforeEach
     fun setUp() {
         getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails =
-            GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails(OBVersion.v3_1_8, tppResource)
+            GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails(OBVersion.v3_1_9, tppResource)
     }
 
     @EnabledIfVersion(
         type = "payments",
-        apiVersion = "v3.1.8",
+        apiVersion = "v3.1.9",
         operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails"],
         apis = ["international-payments", "international-payment-consents"],
         compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
     )
     @Test
-    fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_AGREED_v3_1_8() {
+    fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_AGREED_v3_1_9() {
         getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails.getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_AGREED_Test()
     }
 
     @EnabledIfVersion(
         type = "payments",
-        apiVersion = "v3.1.8",
+        apiVersion = "v3.1.9",
         operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails"],
         apis = ["international-payments", "international-payment-consents"],
         compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
     )
     @Test
-    fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_ACTUAL_v3_1_8() {
+    fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_ACTUAL_v3_1_9() {
         getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails.getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_ACTUAL_Test()
     }
 
     @EnabledIfVersion(
         type = "payments",
-        apiVersion = "v3.1.8",
+        apiVersion = "v3.1.9",
         operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails"],
         apis = ["international-payments", "international-payment-consents"],
         compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
     )
     @Test
-    fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_INDICATIVE_v3_1_8() {
+    fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_INDICATIVE_v3_1_9() {
         getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails.getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_INDICATIVE_Test()
     }
 
     @EnabledIfVersion(
         type = "payments",
-        apiVersion = "v3.1.8",
+        apiVersion = "v3.1.9",
         operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails"],
         apis = ["international-payments", "international-payment-consents"],
         compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
     )
     @Test
-    fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_v3_1_8_mandatoryFields() {
+    fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_v3_1_9_mandatoryFields() {
         getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails.getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_Test()
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/junit/v3_1_9/GetInternationalScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/junit/v3_1_9/GetInternationalScheduledPaymentTest.kt
@@ -1,0 +1,80 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.api.v3_1_8.GetInternationalScheduledPayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getInternationalScheduledPayment: GetInternationalScheduledPayment
+
+    @BeforeEach
+    fun setUp() {
+        getInternationalScheduledPayment = GetInternationalScheduledPayment(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getInternationalScheduledPayments_rateType_AGREED_v3_1_9() {
+        getInternationalScheduledPayment.getInternationalScheduledPayments_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getInternationalScheduledPayments_rateType_ACTUAL_v3_1_9() {
+        getInternationalScheduledPayment.getInternationalScheduledPayments_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getInternationalScheduledPayments_rateType_INDICATIVE_v3_1_9() {
+        getInternationalScheduledPayment.getInternationalScheduledPayments_rateType_INDICATIVE_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun getInternationalScheduledPayments_v3_1_9_mandatoryFields() {
+        getInternationalScheduledPayment.getInternationalScheduledPayments_mandatoryFields_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Disabled
+    @Test
+    fun shouldGetInternationalScheduledPayments_withReadRefund_v3_1_9() {
+        getInternationalScheduledPayment.shouldGetInternationalScheduledPayments_withReadRefund_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/junit/v3_1_9/GetInternationalScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/junit/v3_1_9/GetInternationalScheduledPaymentTest.kt
@@ -21,8 +21,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
     fun getInternationalScheduledPayments_rateType_AGREED_v3_1_9() {
@@ -33,8 +32,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
     fun getInternationalScheduledPayments_rateType_ACTUAL_v3_1_9() {
@@ -45,8 +43,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
     fun getInternationalScheduledPayments_rateType_INDICATIVE_v3_1_9() {
@@ -57,8 +54,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Test
     fun getInternationalScheduledPayments_v3_1_9_mandatoryFields() {
@@ -69,8 +65,7 @@ class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.Tp
         type = "payments",
         apiVersion = "v3.1.9",
         operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
-        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"],
-        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
     )
     @Disabled
     @Test


### PR DESCRIPTION
Adding functional tests for OBIE Read/Write API v3.1.9 endpoints.

v3.1.9 is functionally equivalent to v3.1.8 (for the routes we currently support), therefore all tests reuse the v3.1.8 logic.