### PR TITLE
494: Fixing payment consent tests to send a detached JWS signature

### DIFF
--- a/src/test/kotlin/com/forgerock/securebanking/framework/data/Tpp.kt
+++ b/src/test/kotlin/com/forgerock/securebanking/framework/data/Tpp.kt
@@ -3,10 +3,11 @@ package com.forgerock.securebanking.framework.data
 import com.forgerock.securebanking.framework.configuration.OB_TPP_EIDAS_SIGNING_KEY_PATH
 import com.forgerock.securebanking.framework.configuration.OB_TPP_OB_EIDAS_TEST_SIGNING_KID
 import com.forgerock.securebanking.framework.http.fuel.responseObject
+import com.forgerock.securebanking.framework.signature.signPayload
 import com.forgerock.securebanking.framework.utils.GsonUtils
 import com.forgerock.securebanking.framework.utils.FileUtils
 import com.forgerock.uk.openbanking.support.discovery.asDiscovery
-import com.forgerock.uk.openbanking.support.loadRsaPrivateKey
+import com.forgerock.uk.openbanking.support.getRsaPrivateKey
 import com.forgerock.uk.openbanking.support.registration.registerTpp
 import com.forgerock.uk.openbanking.support.registration.unregisterTpp
 import com.forgerock.uk.openbanking.framework.accesstoken.model.AccessTokenRequest
@@ -16,11 +17,16 @@ import com.forgerock.uk.openbanking.framework.configuration.OB_ORGANISATION_ID
 import com.forgerock.uk.openbanking.framework.configuration.OB_SOFTWARE_ID
 import com.forgerock.uk.openbanking.framework.configuration.SSA_MATLS_URL_SANDBOX
 import com.forgerock.uk.openbanking.framework.configuration.TOKEN_URL_SANDBOX
+import com.forgerock.uk.openbanking.framework.constants.REDIRECT_URI
+import com.forgerock.uk.openbanking.support.general.GeneralAS.Companion
+import com.forgerock.uk.openbanking.support.general.GeneralAS.GrantTypes
+import com.forgerock.uk.openbanking.support.payment.PaymentApiClient
 import com.forgerock.uk.openbanking.support.registration.UserRegistrationRequest
 import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.core.Response
+import com.github.kittinunf.fuel.core.extensions.authentication
 import com.github.kittinunf.fuel.core.isSuccessful
 import com.github.kittinunf.result.Result
 import com.nimbusds.jose.JOSEObjectType
@@ -39,9 +45,11 @@ import java.util.*
 data class Tpp(
     val sessionToken: String, val directoryUser: UserRegistrationRequest,
     val softwareStatement: SoftwareStatement, val privateCert: String,
-    val publicCert: String, val signingKid: String, val signingKey: String
+    val publicCert: String, val signingKid: String, val signingKeyPath: String
 ) {
 
+    var signingKey = getRsaPrivateKey(signingKeyPath)!!
+    var paymentApiClient = PaymentApiClient(this)
     lateinit var registrationResponse: RegistrationResponse
     lateinit var accessToken: String
 
@@ -97,11 +105,10 @@ data class Tpp(
     }
 
     private fun signRegistrationRequest(registrationRequest: RegistrationRequest): String {
-        val key = loadRsaPrivateKey(this.signingKey)
         return Jwts.builder()
             .setHeaderParam("kid", signingKid)
             .setPayload(GsonUtils.gson.toJson(registrationRequest))
-            .signWith(key, SignatureAlgorithm.forName(asDiscovery.request_object_signing_alg_values_supported[0]))
+            .signWith(signingKey, SignatureAlgorithm.forName(asDiscovery.request_object_signing_alg_values_supported[0]))
             .compact()
     }
 
@@ -138,6 +145,7 @@ data class Tpp(
         }
     }
 
+    // TODO: Refactor acquireAccessToken and getClientCredentialsAccessToken into one reusable method for getting access tokens
     private fun acquireAccessToken(jws: SignedJWT): AccessTokenResponse {
         val accessTokenRequest = AccessTokenRequest(client_assertion = jws.serialize())
 
@@ -159,5 +167,31 @@ data class Tpp(
             }", r.component2()
         )
         return r.get()
+    }
+
+    fun getClientCredentialsAccessToken(scopes: String): AccessToken {
+        val requestParameters = ClientCredentialData(
+            sub = registrationResponse.client_id,
+            iss = registrationResponse.client_id,
+            aud = asDiscovery.issuer
+        )
+        val signedPayload = signPayload(requestParameters, signingKey, signingKid)
+        val body = listOf(
+            "grant_type" to GrantTypes.CLIENT_CREDENTIALS,
+            "redirect_uri" to REDIRECT_URI,
+            "client_assertion_type" to Companion.CLIENT_ASSERTION_TYPE,
+            "scope" to scopes,
+            "client_assertion" to signedPayload
+        )
+        val (_, accessTokenResponse, result) = Fuel.post(asDiscovery.token_endpoint, parameters = body)
+            .authentication()
+            .basic(registrationResponse.client_id, registrationResponse.client_secret!!)
+            .responseObject<AccessToken>()
+        if (!accessTokenResponse.isSuccessful) throw AssertionError(
+            "Could not get access token: \n" + result.component2()?.errorData?.toString(
+                Charsets.UTF_8
+            ), result.component2()
+        )
+        return result.get()
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/account/AccountRS.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/account/AccountRS.kt
@@ -1,17 +1,11 @@
 package com.forgerock.uk.openbanking.support.account
 
 import com.forgerock.securebanking.framework.configuration.IG_SERVER
-import com.forgerock.uk.openbanking.framework.constants.REDIRECT_URI
 import com.forgerock.securebanking.framework.data.AccessToken
-import com.forgerock.securebanking.framework.data.ClientCredentialData
 import com.forgerock.securebanking.framework.data.Tpp
 import com.forgerock.securebanking.framework.http.fuel.jsonBody
 import com.forgerock.securebanking.framework.http.fuel.responseObject
-import com.forgerock.securebanking.framework.signature.signPayload
-import com.forgerock.uk.openbanking.support.discovery.asDiscovery
 import com.forgerock.uk.openbanking.support.discovery.rsDiscovery
-import com.forgerock.uk.openbanking.support.general.GeneralAS.Companion.CLIENT_ASSERTION_TYPE
-import com.forgerock.uk.openbanking.support.general.GeneralAS.GrantTypes.CLIENT_CREDENTIALS
 import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.ResponseResultOf
 import com.github.kittinunf.fuel.core.isSuccessful
@@ -20,26 +14,7 @@ import uk.org.openbanking.datamodel.account.OBReadAccount3
 class AccountRS {
 
     fun getAccessToken(tpp: Tpp): AccessToken {
-        val requestParameters = ClientCredentialData(
-            sub = tpp.registrationResponse.client_id,
-            iss = tpp.registrationResponse.client_id,
-            aud = asDiscovery.issuer
-        )
-        val signedPayload = signPayload(requestParameters, tpp.signingKey, tpp.signingKid)
-
-        val body = listOf(
-            "grant_type" to CLIENT_CREDENTIALS,
-            "redirect_uri" to REDIRECT_URI,
-            "client_assertion_type" to CLIENT_ASSERTION_TYPE,
-            "scope" to "accounts",
-            "client_assertion" to signedPayload
-        )
-
-        val (_, accessTokenResponse, result) = Fuel.post(asDiscovery.token_endpoint, body)
-            .header("Content-Type", "application/x-www-form-urlencoded")
-            .responseObject<AccessToken>()
-        if (!accessTokenResponse.isSuccessful) throw AssertionError("Could not get access token", result.component2())
-        return result.get()
+        return tpp.getClientCredentialsAccessToken("accounts")
     }
 
     inline fun <reified T : Any> consent(consentUrl: String, consentRequest: Any, tpp: Tpp): T {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/account/AccountRS.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/account/AccountRS.kt
@@ -13,12 +13,12 @@ import uk.org.openbanking.datamodel.account.OBReadAccount3
 
 class AccountRS {
 
-    fun getAccessToken(tpp: Tpp): AccessToken {
+    fun getClientCredentialsAccessToken(tpp: Tpp): AccessToken {
         return tpp.getClientCredentialsAccessToken("accounts")
     }
 
     inline fun <reified T : Any> consent(consentUrl: String, consentRequest: Any, tpp: Tpp): T {
-        val accessToken = getAccessToken(tpp).access_token
+        val accessToken = getClientCredentialsAccessToken(tpp).access_token
         val (_, consentResponse, r) = Fuel.post(consentUrl)
             .jsonBody(consentRequest)
             .header("Authorization", "Bearer $accessToken")
@@ -32,7 +32,7 @@ class AccountRS {
     }
 
     inline fun <reified T : Any> getConsent(consentUrl: String, tpp: Tpp): T {
-        val accessToken = getAccessToken(tpp).access_token
+        val accessToken = getClientCredentialsAccessToken(tpp).access_token
         val (_, consentResponse, r) = Fuel.get(consentUrl)
             .header("Authorization", "Bearer $accessToken")
             .header("x-fapi-financial-id", rsDiscovery.Data.FinancialId ?: "")
@@ -45,7 +45,7 @@ class AccountRS {
     }
 
     inline fun <reified T : Any> deleteConsent(consentUrl: String, tpp: Tpp): T {
-        val accessToken = getAccessToken(tpp).access_token
+        val accessToken = getClientCredentialsAccessToken(tpp).access_token
         val (_, consentResponse, r) = Fuel.delete(consentUrl)
             .header("Authorization", "Bearer $accessToken")
             .header("x-fapi-financial-id", rsDiscovery.Data.FinancialId ?: "")

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/onboarding/ManualOnboardingTool.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/onboarding/ManualOnboardingTool.kt
@@ -1,5 +1,6 @@
 package com.forgerock.uk.openbanking.support.onboarding
 
+import com.forgerock.securebanking.framework.cert.loadRsaPrivateKey
 import com.forgerock.securebanking.framework.data.RequestParameters
 import com.forgerock.securebanking.framework.http.fuel.initFuel
 import com.forgerock.securebanking.framework.signature.signPayload
@@ -81,7 +82,7 @@ fun signClaims(/*ssaPath : String,*/ signingKeyPath: String, signingKid: String,
     val claims = RequestParameters.Claims(idToken, userInfo)
     val requestParameters = RequestParameters(claims = claims, client_id = clientId, iss = clientId)
     println("Request Parameters is \n$requestParameters")
-    val signedPayload = signPayload(requestParameters, signingKey, signingKid)
+    val signedPayload = signPayload(requestParameters, loadRsaPrivateKey(signingKey)!!, signingKid)
     println("Signed Request Parameters: \n$signedPayload")
 
     return signedPayload

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/JwsSignatureProducer.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/JwsSignatureProducer.kt
@@ -64,8 +64,8 @@ open class DefaultJwsSignatureProducer(private val tpp: Tpp, private val b64Head
 /**
  * Implementation for testing purposes, produces an invalid detached JWS
  */
-class BadJwsSignatureProducer: JwsSignatureProducer {
-    override fun createDetachedSignature(jsonPayload: String) = INVALID_FORMAT_DETACHED_JWS
+class BadJwsSignatureProducer(private val badSignature: String = INVALID_FORMAT_DETACHED_JWS): JwsSignatureProducer {
+    override fun createDetachedSignature(jsonPayload: String) = badSignature
 }
 
 /**

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/JwsSignatureProducer.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/JwsSignatureProducer.kt
@@ -1,0 +1,76 @@
+package com.forgerock.uk.openbanking.support.payment
+
+import com.forgerock.securebanking.framework.configuration.ISS_CLAIM_VALUE
+import com.forgerock.securebanking.framework.data.Tpp
+import com.forgerock.uk.openbanking.framework.constants.INVALID_FORMAT_DETACHED_JWS
+import com.forgerock.uk.openbanking.framework.constants.INVALID_SIGNING_KID
+import com.forgerock.uk.openbanking.framework.constants.TAN
+import io.jsonwebtoken.JwtBuilder
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import java.util.HashMap
+
+interface JwsSignatureProducer {
+    fun createDetachedSignature(jsonPayload: String): String
+}
+
+/**
+ * Default implementation of JwsSignatureProducer, creates detached signatures using the provided Tpp's signingKey.
+ * Adds headers to produce a JWS which is compliant with OBIE requirements.
+ *
+ * A b64 header may be added (it is omitted by default as it must not be supplied in OBIE version>= 3.1.4), if the
+ * b64HeaderValue is not null then it is added as either true or false.
+ */
+open class DefaultJwsSignatureProducer(private val tpp: Tpp, private val b64HeaderValue: Boolean? = null) :
+    JwsSignatureProducer {
+
+    private fun addHeaders(jwtBuilder: JwtBuilder) {
+        val headers = HashMap<String, Any>()
+        headers["kid"] = getKid()
+        headers["http://openbanking.org.uk/iat"] = System.currentTimeMillis() / 1000 - 10
+        headers["http://openbanking.org.uk/iss"] = ISS_CLAIM_VALUE
+        headers["http://openbanking.org.uk/tan"] = TAN
+        headers["crit"] = listOf(
+            "http://openbanking.org.uk/iat",
+            "http://openbanking.org.uk/iss",
+            "http://openbanking.org.uk/tan"
+        )
+        headers["typ"] = "JOSE"
+        if (b64HeaderValue != null) {
+            headers["b64"] = b64HeaderValue
+        }
+        jwtBuilder.setHeaderParams(headers)
+    }
+
+    protected open fun getKid() = tpp.signingKid
+
+    private fun createSignature(jsonPayload: String): String {
+        val jwtBuilder = Jwts.builder()
+        addHeaders(jwtBuilder)
+        return jwtBuilder.setPayload(jsonPayload)
+            .signWith(tpp.signingKey, SignatureAlgorithm.PS256)
+            .compact()
+    }
+
+    override fun createDetachedSignature(jsonPayload: String): String {
+        val signature = createSignature(jsonPayload)
+
+        // Remove the payload portion to produce a detached sig
+        val jwtElements = signature.split('.')
+        return jwtElements[0] + ".." + jwtElements[2]
+    }
+}
+
+/**
+ * Implementation for testing purposes, produces an invalid detached JWS
+ */
+class BadJwsSignatureProducer: JwsSignatureProducer {
+    override fun createDetachedSignature(jsonPayload: String) = INVALID_FORMAT_DETACHED_JWS
+}
+
+/**
+ * Implementation for testing purposes, produces a detached JWS with and invalid kid header value
+ */
+class InvalidKidJwsSignatureProducer(tpp: Tpp, b64HeaderValue: Boolean? = null): DefaultJwsSignatureProducer(tpp, b64HeaderValue) {
+    override fun getKid() = INVALID_SIGNING_KID
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentAS.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentAS.kt
@@ -1,27 +1,20 @@
 package com.forgerock.uk.openbanking.support.payment
 
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRFinancialAccount
-import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.common.FRAccountIdentifier
 import com.forgerock.securebanking.framework.configuration.AM_COOKIE_NAME
 import com.forgerock.securebanking.framework.configuration.RCS_SERVER
-import com.forgerock.uk.openbanking.framework.constants.REDIRECT_URI
 import com.forgerock.securebanking.framework.data.AccessToken
 import com.forgerock.securebanking.framework.data.RegistrationResponse
-import com.forgerock.securebanking.framework.data.RequestParameters
 import com.forgerock.securebanking.framework.data.Tpp
 import com.forgerock.securebanking.framework.http.fuel.jsonBody
 import com.forgerock.securebanking.framework.http.fuel.responseObject
-import com.forgerock.securebanking.framework.signature.signPayload
-import com.forgerock.securebanking.framework.utils.GsonUtils
 import com.forgerock.securebanking.framework.utils.GsonUtils.Companion.gson
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBConstants
 import com.forgerock.uk.openbanking.support.discovery.asDiscovery
 import com.forgerock.uk.openbanking.support.general.GeneralAS
 import com.forgerock.uk.openbanking.support.registration.UserRegistrationRequest
 import com.github.kittinunf.fuel.Fuel
-import com.github.kittinunf.fuel.core.extensions.authentication
 import com.github.kittinunf.fuel.core.isSuccessful
-import com.google.gson.Gson
 import com.google.gson.JsonParser
 
 
@@ -36,7 +29,11 @@ class PaymentAS : GeneralAS() {
         val debtorAccount: FRFinancialAccount
     )
 
-    fun getAccessToken(
+    /**
+     * Authorizes a consent and returns an AccessToken with grant_type authorization_code, this token can then be used
+     * in subsequent operations on the consent (such as making a payment)
+     */
+    fun authorizeConsent(
         consentId: String,
         registrationResponse: RegistrationResponse,
         psu: UserRegistrationRequest,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentApiClient.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentApiClient.kt
@@ -1,0 +1,115 @@
+package com.forgerock.uk.openbanking.support.payment
+
+import com.forgerock.securebanking.framework.data.AccessToken
+import com.forgerock.securebanking.framework.data.Tpp
+import com.forgerock.securebanking.framework.http.fuel.defaultMapper
+import com.forgerock.securebanking.framework.http.fuel.responseObject
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBConstants
+import com.forgerock.uk.openbanking.support.discovery.rsDiscovery
+import com.github.kittinunf.fuel.Fuel
+import com.github.kittinunf.fuel.core.Request
+import com.github.kittinunf.fuel.core.isSuccessful
+import java.util.*
+
+val defaultPaymentScopesForAccessToken =
+    com.forgerock.uk.openbanking.support.discovery.asDiscovery.scopes_supported.intersect(
+        listOf(
+            OBConstants.Scope.OPENID,
+            OBConstants.Scope.ACCOUNTS,
+            OBConstants.Scope.PAYMENTS
+        )
+    ).joinToString(separator = " ")
+
+/**
+ * Rest Client used to call payment API endpoints
+ */
+class PaymentApiClient(val tpp: Tpp) {
+
+    inner class PaymentApiRequestBuilder(val request: Request) {
+
+        var jwsSignatureProducer: JwsSignatureProducer? = null
+        var jsonBody: String? = null
+
+        fun configureJwsSignatureProducer(jwsSignatureProducer: JwsSignatureProducer?): PaymentApiRequestBuilder {
+            this.jwsSignatureProducer = jwsSignatureProducer
+            return this
+        }
+
+        fun configureDefaultJwsSignatureProducer(): PaymentApiRequestBuilder {
+            jwsSignatureProducer = DefaultJwsSignatureProducer(tpp)
+            return this
+        }
+
+        fun addBody(body: Any): PaymentApiRequestBuilder {
+            // store the body string in a field so we can compute a signature later (if required)
+            jsonBody = defaultMapper.writeValueAsString(body)
+            request.body(jsonBody!!)
+            return this
+        }
+
+        fun addAuthorization(accessToken: AccessToken): PaymentApiRequestBuilder {
+            request.header("Authorization", "Bearer ${accessToken.access_token}")
+            return this
+        }
+
+        fun addIdempotencyKeyHeader(postRequest: Request, idempotencyKey: String? = null): PaymentApiRequestBuilder {
+            postRequest.header("x-idempotency-key", idempotencyKey ?: UUID.randomUUID())
+            return this
+        }
+
+        inline fun <reified T : Any> sendRequest(): T {
+            if (jwsSignatureProducer != null && jsonBody != null) {
+                val detachedSignature = jwsSignatureProducer?.createDetachedSignature(jsonBody!!)
+                if (detachedSignature != null) {
+                    request.header("x-jws-signature", detachedSignature)
+                }
+            }
+
+            // TODO x-fapi-financial-id is not necessary anymore, only add it for the legacy versions which need it
+            request.header("x-fapi-financial-id", rsDiscovery.Data.FinancialId ?: "")
+            val (_, response, result) = request.responseObject<T>()
+
+            if (!response.isSuccessful) {
+                throw AssertionError(
+                    "Could not create the consent: \n" + result.component2()?.errorData?.toString(Charsets.UTF_8),
+                    result.component2()
+                )
+            }
+
+            if (response.header("x-jws-signature").isNullOrEmpty()) {
+                throw AssertionError(
+                    "The response should have 'x-jws-signature' header for the consent : ${result.get()}"
+                )
+            }
+            return result.get()
+        }
+    }
+
+    fun createEmptyPostRequest(url: String): PaymentApiRequestBuilder {
+        return PaymentApiRequestBuilder(Fuel.post(url))
+    }
+
+    fun createDefaultPostRequest(
+        url: String,
+        accessToken: AccessToken,
+        body: Any
+    ) = createEmptyPostRequest(url).addAuthorization(accessToken).addBody(body).configureDefaultJwsSignatureProducer()
+
+    fun createGetRequest(url: String): PaymentApiRequestBuilder {
+        return PaymentApiRequestBuilder(Fuel.get(url))
+    }
+
+    /**
+     * Submits a HTTP GET request using default configuration
+     */
+    inline fun <reified T : Any> sendGetRequest(url: String, accessToken: AccessToken): T {
+        return createGetRequest(url).addAuthorization(accessToken).sendRequest()
+    }
+
+    /**
+     * Submits a HTTP Post request using default configuration
+     */
+    inline fun <reified T : Any> sendPostRequest(url: String, accessToken: AccessToken, body: Any): T {
+        return createDefaultPostRequest(url, accessToken, body).sendRequest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentApiClient.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentApiClient.kt
@@ -85,32 +85,38 @@ class PaymentApiClient(val tpp: Tpp) {
         }
     }
 
-    fun createEmptyPostRequest(url: String): PaymentApiRequestBuilder {
+    fun newPostRequestBuilder(url: String): PaymentApiRequestBuilder {
         return PaymentApiRequestBuilder(Fuel.post(url))
     }
 
-    fun createDefaultPostRequest(
+    fun newGetRequestBuilder(url: String): PaymentApiRequestBuilder {
+        return PaymentApiRequestBuilder(Fuel.get(url))
+    }
+
+    /**
+     * Creates a PaymentApiRequestBuilder for HTTP Post request with the following configuration:
+     * - authorization token add to header
+     * - json body added
+     * - detached JWS signature header
+     */
+    fun newPostRequestBuilder(
         url: String,
         accessToken: AccessToken,
         body: Any
-    ) = createEmptyPostRequest(url).addAuthorization(accessToken).addBody(body).configureDefaultJwsSignatureProducer()
-
-    fun createGetRequest(url: String): PaymentApiRequestBuilder {
-        return PaymentApiRequestBuilder(Fuel.get(url))
-    }
+    ) = newPostRequestBuilder(url).addAuthorization(accessToken).addBody(body).configureDefaultJwsSignatureProducer()
 
     /**
      * Submits a HTTP GET request using default configuration
      */
     inline fun <reified T : Any> sendGetRequest(url: String, accessToken: AccessToken): T {
-        return createGetRequest(url).addAuthorization(accessToken).sendRequest()
+        return newGetRequestBuilder(url).addAuthorization(accessToken).sendRequest()
     }
 
     /**
      * Submits a HTTP Post request using default configuration
      */
     inline fun <reified T : Any> sendPostRequest(url: String, accessToken: AccessToken, body: Any): T {
-        return createDefaultPostRequest(url, accessToken, body).sendRequest()
+        return newPostRequestBuilder(url, accessToken, body).sendRequest()
     }
 
     inline fun <reified T : Any> getConsent(url: String, consentId: String, accessToken: AccessToken): T {
@@ -125,6 +131,6 @@ class PaymentApiClient(val tpp: Tpp) {
         url: String,
         accessToken: AccessToken,
         body: Any
-    ) = createDefaultPostRequest(url, accessToken, body)
+    ) = newPostRequestBuilder(url, accessToken, body)
         .addIdempotencyKeyHeader()
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/registration/Registration.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/registration/Registration.kt
@@ -2,14 +2,13 @@ package com.forgerock.uk.openbanking.support.registration
 
 import com.forgerock.securebanking.framework.configuration.OB_TPP_EIDAS_SIGNING_KEY_PATH
 import com.forgerock.securebanking.framework.configuration.OB_TPP_OB_EIDAS_TEST_SIGNING_KID
-import com.forgerock.securebanking.framework.configuration.OB_TPP_PRE_EIDAS_SIGNING_KID
 import com.forgerock.securebanking.framework.data.RegistrationRequest
 import com.forgerock.securebanking.framework.data.RegistrationResponse
 import com.forgerock.securebanking.framework.http.fuel.responseObject
 import com.forgerock.securebanking.framework.utils.GsonUtils
 import com.forgerock.securebanking.framework.utils.FileUtils
 import com.forgerock.uk.openbanking.support.discovery.asDiscovery
-import com.forgerock.uk.openbanking.support.loadRsaPrivateKey
+import com.forgerock.uk.openbanking.support.getRsaPrivateKey
 import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.Headers
@@ -66,7 +65,7 @@ fun signOBEidasRegistrationRequest(): Pair<String, RegistrationRequest> {
     val ssa = FileUtils().getStringContent("OB_TPP_EIDAS_SSA_PATH")
     val registrationRequest = RegistrationRequest(software_statement = ssa)
     val privateKey = FileUtils().getStringContent(OB_TPP_EIDAS_SIGNING_KEY_PATH)
-    val key = loadRsaPrivateKey(privateKey)
+    val key = getRsaPrivateKey(privateKey)
     val signedRegistrationRequest = Jwts.builder()
         .setHeaderParam("kid", OB_TPP_OB_EIDAS_TEST_SIGNING_KID)
         .setPayload(GsonUtils.gson.toJson(registrationRequest))

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
@@ -262,17 +262,7 @@ class CreateDomesticPayment(
     }
 
     private fun getPatchedConsent(consent: OBWriteDomesticConsentResponse5): OBWriteDomesticConsentResponse5 {
-        val patchedConsent = paymentApiClient.getConsent<OBWriteDomesticConsentResponse5>(
-            paymentLinks.GetDomesticPaymentConsent,
-            consent.data.consentId,
-            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
-        )
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-        return patchedConsent
+        return createDomesticPaymentsConsentsApi.getPatchedConsent(consent)
     }
 
     private fun submitPaymentForPatchedConsent(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
@@ -37,6 +37,7 @@ class CreateDomesticPayment(
 
     private val createDomesticPaymentsConsentsApi = CreateDomesticPaymentsConsents(version, tppResource)
     private val paymentApiClient = tppResource.tpp.paymentApiClient
+    private val createPaymentUrl = createDomesticPaymentsConsentsApi.paymentLinks.CreateDomesticPayment
 
     fun createDomesticPaymentsTest() {
         // Given
@@ -93,7 +94,7 @@ class CreateDomesticPayment(
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            paymentApiClient.buildSubmitPaymentRequest(createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPaymentConsent, accessToken, paymentSubmissionRequest)
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
                 .configureJwsSignatureProducer(BadJwsSignatureProducer()).sendRequest()
         }
 
@@ -118,7 +119,7 @@ class CreateDomesticPayment(
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            paymentApiClient.buildSubmitPaymentRequest(createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPaymentConsent, accessToken, paymentSubmissionRequest)
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
                 .configureJwsSignatureProducer(null).sendRequest()
         }
 
@@ -143,7 +144,7 @@ class CreateDomesticPayment(
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            paymentApiClient.buildSubmitPaymentRequest(createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPaymentConsent, accessToken, paymentSubmissionRequest)
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
                 .configureJwsSignatureProducer(DefaultJwsSignatureProducer(tppResource.tpp, false)).sendRequest()
         }
 
@@ -168,7 +169,7 @@ class CreateDomesticPayment(
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            paymentApiClient.buildSubmitPaymentRequest(createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPaymentConsent, accessToken, paymentSubmissionRequest)
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
                 .configureJwsSignatureProducer(InvalidKidJwsSignatureProducer(tppResource.tpp)).sendRequest()
         }
 
@@ -201,7 +202,7 @@ class CreateDomesticPayment(
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            paymentApiClient.buildSubmitPaymentRequest(createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPaymentConsent, accessToken, paymentSubmissionRequest)
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
                 .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidConsentId)).sendRequest()
         }
 
@@ -234,7 +235,7 @@ class CreateDomesticPayment(
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            paymentApiClient.buildSubmitPaymentRequest(createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPaymentConsent, accessToken, paymentSubmissionRequest)
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
                 .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidAmount)).sendRequest()
         }
 
@@ -278,7 +279,7 @@ class CreateDomesticPayment(
     ): OBWriteDomesticResponse5 {
         val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
         return paymentApiClient.submitPayment(
-            createDomesticPaymentsConsentsApi.paymentLinks.CreateDomesticPayment,
+            createPaymentUrl,
             authorizationToken,
             paymentSubmissionRequest
         )

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
@@ -20,7 +20,6 @@ import com.forgerock.uk.openbanking.support.payment.BadJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.DefaultJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.InvalidKidJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.api.v3_1_8.CreateDomesticPaymentsConsents
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
@@ -15,6 +15,7 @@ import com.forgerock.uk.openbanking.framework.errors.INVALID_FORMAT_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.errors.NO_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.errors.PAYMENT_SUBMISSION_ALREADY_EXISTS
 import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.BadJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.DefaultJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.InvalidKidJwsSignatureProducer
@@ -37,7 +38,8 @@ class CreateDomesticPayment(
 
     private val createDomesticPaymentsConsentsApi = CreateDomesticPaymentsConsents(version, tppResource)
     private val paymentApiClient = tppResource.tpp.paymentApiClient
-    private val createPaymentUrl = createDomesticPaymentsConsentsApi.paymentLinks.CreateDomesticPayment
+    private val paymentLinks = getPaymentsApiLinks(version)
+    private val createPaymentUrl = paymentLinks.CreateDomesticPayment
 
     fun createDomesticPaymentsTest() {
         // Given
@@ -261,7 +263,7 @@ class CreateDomesticPayment(
 
     private fun getPatchedConsent(consent: OBWriteDomesticConsentResponse5): OBWriteDomesticConsentResponse5 {
         val patchedConsent = paymentApiClient.getConsent<OBWriteDomesticConsentResponse5>(
-            createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPaymentConsent,
+            paymentLinks.GetDomesticPaymentConsent,
             consent.data.consentId,
             tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
         )

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPayment.kt
@@ -12,7 +12,8 @@ import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.api.v3_1_8.CreateDomesticPaymentsConsents
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.payment.OBReadRefundAccountEnum
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticResponse5
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory
 
 class GetDomesticPayment(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPayment.kt
@@ -6,11 +6,9 @@ import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
-import com.forgerock.securebanking.framework.http.fuel.defaultMapper
-import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
+import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.api.v3_1_8.CreateDomesticPaymentsConsents
 import org.assertj.core.api.Assertions
 import uk.org.openbanking.datamodel.payment.*
@@ -22,78 +20,22 @@ class GetDomesticPayment(
 ) {
 
     private val createDomesticPaymentsConsentsApi = CreateDomesticPaymentsConsents(version, tppResource)
+    private val createDomesticPaymentApi = CreateDomesticPayment(version, tppResource)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun getDomesticPaymentsTest() {
         // Given
         val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndGetAccessToken(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(PaymentFactory.mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteDomesticResponse5>(
-            createDomesticPaymentsConsentsApi.paymentLinks.CreateDomesticPayment,
-            paymentSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.domesticPaymentId).isNotEmpty()
+        val paymentResponse = createDomesticPaymentApi.submitPayment(consentRequest)
 
         // When
-        val paymentResult = PaymentRS().getPayment<OBWriteDomesticResponse5>(
-            PaymentFactory.urlWithDomesticPaymentId(
-                createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPayment,
-                submissionResponse.data.domesticPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val getPaymentResponse = getDomesticPayment(paymentResponse)
 
         // Then
-        assertThat(paymentResult).isNotNull()
-        assertThat(paymentResult.data.domesticPaymentId).isNotEmpty()
-        assertThat(paymentResult.data.creationDateTime).isNotNull()
-        Assertions.assertThat(paymentResult.data.status.toString()).`is`(Status.paymentCondition)
+        assertThat(getPaymentResponse).isNotNull()
+        assertThat(getPaymentResponse.data.domesticPaymentId).isNotEmpty()
+        assertThat(getPaymentResponse.data.creationDateTime).isNotNull()
+        Assertions.assertThat(getPaymentResponse.data.status.toString()).`is`(Status.paymentCondition)
     }
 
     fun shouldGetDomesticPayments_withReadRefundTest() {
@@ -101,7 +43,7 @@ class GetDomesticPayment(
         val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
         consentRequest.data.readRefundAccount = OBReadRefundAccountEnum.YES
 
-        val (consent, accessTokenAuthorizationCode) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndGetAccessToken(
+        val (consent, accessTokenAuthorizationCode) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
             consentRequest
         )
 
@@ -111,67 +53,28 @@ class GetDomesticPayment(
         assertThat(consent.data.readRefundAccount).isEqualTo(OBReadRefundAccountEnum.YES)
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        assertThat(patchedConsent.data.readRefundAccount).isEqualTo(OBReadRefundAccountEnum.YES)
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(PaymentFactory.mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteDomesticResponse5>(
-            createDomesticPaymentsConsentsApi.paymentLinks.CreateDomesticPayment,
-            paymentSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.domesticPaymentId).isNotEmpty()
+        val paymentResponse = createDomesticPaymentApi.submitPayment(consent, accessTokenAuthorizationCode)
 
         // When
-        val paymentResult = PaymentRS().getPayment<OBWriteDomesticResponse5>(
-            PaymentFactory.urlWithDomesticPaymentId(
-                createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPayment,
-                submissionResponse.data.domesticPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val getPaymentResponse = getDomesticPayment(paymentResponse)
 
         // Then
-        assertThat(paymentResult).isNotNull()
-        assertThat(paymentResult.data.domesticPaymentId).isNotEmpty()
-        assertThat(paymentResult.data.creationDateTime).isNotNull()
+        assertThat(getPaymentResponse).isNotNull()
+        assertThat(getPaymentResponse.data.domesticPaymentId).isNotEmpty()
+        assertThat(getPaymentResponse.data.creationDateTime).isNotNull()
         //TODO: Waiting for the fix from the issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/241
-        assertThat(paymentResult.data.refund.account.identification).isEqualTo(consent.data.initiation.debtorAccount.identification)
-        Assertions.assertThat(paymentResult.data.status.toString()).`is`(Status.paymentCondition)
+        assertThat(getPaymentResponse.data.refund.account.identification).isEqualTo(consent.data.initiation.debtorAccount.identification)
+        Assertions.assertThat(getPaymentResponse.data.status.toString()).`is`(Status.paymentCondition)
+    }
+
+    private fun getDomesticPayment(paymentResponse: OBWriteDomesticResponse5): OBWriteDomesticResponse5 {
+        val getDomesticPaymentUrl = PaymentFactory.urlWithDomesticPaymentId(
+            createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPayment,
+            paymentResponse.data.domesticPaymentId
+        )
+        return paymentApiClient.sendGetRequest(
+            getDomesticPaymentUrl,
+            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
+        )
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPayment.kt
@@ -36,7 +36,7 @@ class GetDomesticPayment(
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -112,7 +112,7 @@ class GetDomesticPayment(
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticConsentResponse5>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPayment.kt
@@ -7,6 +7,7 @@ import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.api.v3_1_8.CreateDomesticPaymentsConsents
@@ -21,6 +22,7 @@ class GetDomesticPayment(
 
     private val createDomesticPaymentsConsentsApi = CreateDomesticPaymentsConsents(version, tppResource)
     private val createDomesticPaymentApi = CreateDomesticPayment(version, tppResource)
+    private val paymentLinks = getPaymentsApiLinks(version)
     private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun getDomesticPaymentsTest() {
@@ -69,7 +71,7 @@ class GetDomesticPayment(
 
     private fun getDomesticPayment(paymentResponse: OBWriteDomesticResponse5): OBWriteDomesticResponse5 {
         val getDomesticPaymentUrl = PaymentFactory.urlWithDomesticPaymentId(
-            createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPayment,
+            paymentLinks.GetDomesticPayment,
             paymentResponse.data.domesticPaymentId
         )
         return paymentApiClient.sendGetRequest(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPaymentDomesticPaymentIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPaymentDomesticPaymentIdPaymentDetails.kt
@@ -1,18 +1,12 @@
 package com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.api.v3_1_8
 
 import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
-import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
-import com.forgerock.securebanking.framework.http.fuel.defaultMapper
-import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
+import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.api.v3_1_8.CreateDomesticPaymentsConsents
-import org.assertj.core.api.Assertions
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory
 
@@ -22,76 +16,27 @@ class GetDomesticPaymentDomesticPaymentIdPaymentDetails(
 ) {
 
     private val createDomesticPaymentsConsentsApi = CreateDomesticPaymentsConsents(version, tppResource)
+    private val createDomesticPaymentApi = CreateDomesticPayment(version, tppResource)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun getDomesticPaymentDomesticPaymentIdPaymentDetailsTest() {
         // Given
         val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndGetAccessToken(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(PaymentFactory.mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteDomesticResponse5>(
-            createDomesticPaymentsConsentsApi.paymentLinks.CreateDomesticPayment,
-            paymentSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.domesticPaymentId).isNotEmpty()
+        val paymentResponse = createDomesticPaymentApi.submitPayment(consentRequest)
 
         // When
-        val paymentResult = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
-            PaymentFactory.urlWithDomesticPaymentId(
-                createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPaymentDomesticPaymentIdPaymentDetails,
-                submissionResponse.data.domesticPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
+        val getDomesticPaymentDetailsUrl = PaymentFactory.urlWithDomesticPaymentId(
+            createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPaymentDomesticPaymentIdPaymentDetails,
+            paymentResponse.data.domesticPaymentId
+        )
+        val paymentDetailsResponse = paymentApiClient.sendGetRequest<OBWritePaymentDetailsResponse1>(
+            getDomesticPaymentDetailsUrl,
+            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
         )
 
         // Then
-        assertThat(paymentResult).isNotNull()
-        assertThat(paymentResult.data).isNotNull()
-        assertThat(paymentResult.data.paymentStatus).isNotNull()
+        assertThat(paymentDetailsResponse).isNotNull()
+        assertThat(paymentDetailsResponse.data).isNotNull()
+        assertThat(paymentDetailsResponse.data.paymentStatus).isNotNull()
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPaymentDomesticPaymentIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPaymentDomesticPaymentIdPaymentDetails.kt
@@ -7,7 +7,7 @@ import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory
 
 class GetDomesticPaymentDomesticPaymentIdPaymentDetails(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPaymentDomesticPaymentIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPaymentDomesticPaymentIdPaymentDetails.kt
@@ -4,9 +4,9 @@ import assertk.assertThat
 import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
-import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.api.v3_1_8.CreateDomesticPaymentsConsents
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory
 
@@ -14,9 +14,8 @@ class GetDomesticPaymentDomesticPaymentIdPaymentDetails(
     val version: OBVersion,
     val tppResource: CreateTppCallback.TppResource
 ) {
-
-    private val createDomesticPaymentsConsentsApi = CreateDomesticPaymentsConsents(version, tppResource)
     private val createDomesticPaymentApi = CreateDomesticPayment(version, tppResource)
+    private val paymentLinks = getPaymentsApiLinks(version)
     private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun getDomesticPaymentDomesticPaymentIdPaymentDetailsTest() {
@@ -26,7 +25,7 @@ class GetDomesticPaymentDomesticPaymentIdPaymentDetails(
 
         // When
         val getDomesticPaymentDetailsUrl = PaymentFactory.urlWithDomesticPaymentId(
-            createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPaymentDomesticPaymentIdPaymentDetails,
+            paymentLinks.GetDomesticPaymentDomesticPaymentIdPaymentDetails,
             paymentResponse.data.domesticPaymentId
         )
         val paymentDetailsResponse = paymentApiClient.sendGetRequest<OBWritePaymentDetailsResponse1>(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPaymentDomesticPaymentIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/GetDomesticPaymentDomesticPaymentIdPaymentDetails.kt
@@ -36,7 +36,7 @@ class GetDomesticPaymentDomesticPaymentIdPaymentDetails(
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticConsentResponse5>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/CreateDomesticPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/CreateDomesticPaymentsConsents.kt
@@ -27,8 +27,8 @@ import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFact
 
 class CreateDomesticPaymentsConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
-    val paymentLinks = getPaymentsApiLinks(version)
-    val paymentApiClient = tppResource.tpp.paymentApiClient
+    private val paymentLinks = getPaymentsApiLinks(version)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun createDomesticPaymentsConsentsTest() {
         // Given

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/CreateDomesticPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/CreateDomesticPaymentsConsents.kt
@@ -121,4 +121,17 @@ class CreateDomesticPaymentsConsents(val version: OBVersion, val tppResource: Cr
         )
         return consent to accessTokenAuthorizationCode
     }
+    fun getPatchedConsent(consent: OBWriteDomesticConsentResponse5): OBWriteDomesticConsentResponse5 {
+        val patchedConsent = paymentApiClient.getConsent<OBWriteDomesticConsentResponse5>(
+            paymentLinks.GetDomesticPaymentConsent,
+            consent.data.consentId,
+            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
+        )
+        assertThat(patchedConsent).isNotNull()
+        assertThat(patchedConsent.data).isNotNull()
+        assertThat(patchedConsent.risk).isNotNull()
+        assertThat(patchedConsent.data.consentId).isNotEmpty()
+        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
+        return patchedConsent
+    }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/CreateDomesticPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/CreateDomesticPaymentsConsents.kt
@@ -105,7 +105,7 @@ class CreateDomesticPaymentsConsents(val version: OBVersion, val tppResource: Cr
 
     private fun buildCreateConsentRequest(
         consent: OBWriteDomesticConsent4
-    ) = paymentApiClient.createDefaultPostRequest(
+    ) = paymentApiClient.newPostRequestBuilder(
         paymentLinks.CreateDomesticPaymentConsent,
         tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken),
         consent

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/CreateDomesticPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/CreateDomesticPaymentsConsents.kt
@@ -111,7 +111,7 @@ class CreateDomesticPaymentsConsents(val version: OBVersion, val tppResource: Cr
         consent
     )
 
-    fun createDomesticPaymentsConsentAndGetAccessToken(consentRequest: OBWriteDomesticConsent4): Pair<OBWriteDomesticConsentResponse5, AccessToken> {
+    fun createDomesticPaymentsConsentAndAuthorize(consentRequest: OBWriteDomesticConsent4): Pair<OBWriteDomesticConsentResponse5, AccessToken> {
         val consent = createDomesticPaymentsConsent(consentRequest)
         val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/CreateDomesticPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/CreateDomesticPaymentsConsents.kt
@@ -9,17 +9,16 @@ import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.configuration.psu
 import com.forgerock.securebanking.framework.data.AccessToken
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
-import com.forgerock.securebanking.framework.http.fuel.defaultMapper
-import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
-import com.forgerock.uk.openbanking.framework.constants.INVALID_FORMAT_DETACHED_JWS
-import com.forgerock.uk.openbanking.framework.constants.INVALID_SIGNING_KID
 import com.forgerock.uk.openbanking.framework.errors.INVALID_FORMAT_DETACHED_JWS_ERROR
 import com.forgerock.uk.openbanking.framework.errors.NO_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
+import com.forgerock.uk.openbanking.support.payment.BadJwsSignatureProducer
+import com.forgerock.uk.openbanking.support.payment.DefaultJwsSignatureProducer
+import com.forgerock.uk.openbanking.support.payment.InvalidKidJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.PaymentAS
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
+import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4
@@ -29,6 +28,7 @@ import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFact
 class CreateDomesticPaymentsConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
     val paymentLinks = getPaymentsApiLinks(version)
+    val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun createDomesticPaymentsConsentsTest() {
         // Given
@@ -49,12 +49,7 @@ class CreateDomesticPaymentsConsents(val version: OBVersion, val tppResource: Cr
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().consentNoDetachedJwt<OBWriteDomesticConsentResponse5>(
-                paymentLinks.CreateDomesticPaymentConsent,
-                consentRequest,
-                tppResource.tpp,
-                version
-            )
+            buildCreateConsentRequest(consentRequest).configureJwsSignatureProducer(null).sendRequest()
         }
 
         // Then
@@ -65,26 +60,10 @@ class CreateDomesticPaymentsConsents(val version: OBVersion, val tppResource: Cr
     fun shouldCreateDomesticPaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest() {
         // Given
         val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
-
-        val signedPayload =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(consentRequest),
-                tppResource.tpp.signingKey,
-                tppResource.tpp.signingKid,
-                true
-            )
-
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().consent<OBWriteDomesticConsentResponse5>(
-                paymentLinks.CreateDomesticPaymentConsent,
-                consentRequest,
-                tppResource.tpp,
-                version,
-                signedPayload
-            )
+            buildCreateConsentRequest(consentRequest).configureJwsSignatureProducer(DefaultJwsSignatureProducer(tppResource.tpp, false)).sendRequest()
         }
-
         // Then
         assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
@@ -96,13 +75,7 @@ class CreateDomesticPaymentsConsents(val version: OBVersion, val tppResource: Cr
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().consent<OBWriteDomesticConsentResponse5>(
-                paymentLinks.CreateDomesticPaymentConsent,
-                consentRequest,
-                tppResource.tpp,
-                version,
-                INVALID_FORMAT_DETACHED_JWS
-            )
+            buildCreateConsentRequest(consentRequest).configureJwsSignatureProducer(BadJwsSignatureProducer()).sendRequest()
         }
 
         // Then
@@ -114,22 +87,9 @@ class CreateDomesticPaymentsConsents(val version: OBVersion, val tppResource: Cr
         // Given
         val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
 
-        val signedPayloadConsent =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(consentRequest),
-                tppResource.tpp.signingKey,
-                INVALID_SIGNING_KID
-            )
-
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().consent<OBWriteDomesticConsentResponse5>(
-                paymentLinks.CreateDomesticPaymentConsent,
-                consentRequest,
-                tppResource.tpp,
-                version,
-                signedPayloadConsent
-            )
+            buildCreateConsentRequest(consentRequest).configureJwsSignatureProducer(InvalidKidJwsSignatureProducer(tppResource.tpp)).sendRequest()
         }
 
         // Then
@@ -137,28 +97,23 @@ class CreateDomesticPaymentsConsents(val version: OBVersion, val tppResource: Cr
         assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
     }
 
-    fun createDomesticPaymentsConsent(consentRequest: OBWriteDomesticConsent4): OBWriteDomesticConsentResponse5 {
-        val signedPayloadConsent =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(consentRequest),
-                tppResource.tpp.signingKey,
-                tppResource.tpp.signingKid
-            )
-
-        // When
-        val consent = PaymentRS().consent<OBWriteDomesticConsentResponse5>(
-            paymentLinks.CreateDomesticPaymentConsent,
-            consentRequest,
-            tppResource.tpp,
-            version,
-            signedPayloadConsent
-        )
-        return consent
+    fun createDomesticPaymentsConsent(
+        consent: OBWriteDomesticConsent4,
+    ): OBWriteDomesticConsentResponse5 {
+        return buildCreateConsentRequest(consent).sendRequest()
     }
+
+    private fun buildCreateConsentRequest(
+        consent: OBWriteDomesticConsent4
+    ) = paymentApiClient.createDefaultPostRequest(
+        paymentLinks.CreateDomesticPaymentConsent,
+        tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken),
+        consent
+    )
 
     fun createDomesticPaymentsConsentAndGetAccessToken(consentRequest: OBWriteDomesticConsent4): Pair<OBWriteDomesticConsentResponse5, AccessToken> {
         val consent = createDomesticPaymentsConsent(consentRequest)
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsentFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsentFundsConfirmation.kt
@@ -7,6 +7,7 @@ import com.forgerock.securebanking.framework.configuration.psu
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentAS
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
@@ -21,6 +22,7 @@ class GetDomesticPaymentsConsentFundsConfirmation(
 ) {
 
     private val createDomesticPaymentsConsentsApi = CreateDomesticPaymentsConsents(version, tppResource)
+    private val paymentLinks = getPaymentsApiLinks(version)
 
     fun shouldGetDomesticPaymentConsentsFundsConfirmation_false() {
         // Given
@@ -40,7 +42,7 @@ class GetDomesticPaymentsConsentFundsConfirmation(
         // When
         val result = PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
             PaymentFactory.urlWithConsentId(
-                createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPaymentConsentsConsentIdFundsConfirmation,
+                paymentLinks.GetDomesticPaymentConsentsConsentIdFundsConfirmation,
                 consent.data.consentId
             ),
             accessTokenAuthorizationCode
@@ -71,7 +73,7 @@ class GetDomesticPaymentsConsentFundsConfirmation(
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
                 PaymentFactory.urlWithConsentId(
-                    createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPaymentConsentsConsentIdFundsConfirmation,
+                    paymentLinks.GetDomesticPaymentConsentsConsentIdFundsConfirmation,
                     consent.data.consentId
                 ),
                 accessTokenClientCredentials
@@ -106,7 +108,7 @@ class GetDomesticPaymentsConsentFundsConfirmation(
         // When
         val result = PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
             PaymentFactory.urlWithConsentId(
-                createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPaymentConsentsConsentIdFundsConfirmation,
+                paymentLinks.GetDomesticPaymentConsentsConsentIdFundsConfirmation,
                 consent.data.consentId
             ),
             accessTokenAuthorizationCode

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsentFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsentFundsConfirmation.kt
@@ -30,7 +30,7 @@ class GetDomesticPaymentsConsentFundsConfirmation(
         val consent = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsent(consentRequest)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -65,7 +65,7 @@ class GetDomesticPaymentsConsentFundsConfirmation(
         assertThat(consent.risk).isNotNull()
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
@@ -96,7 +96,7 @@ class GetDomesticPaymentsConsentFundsConfirmation(
         assertThat(consent.risk).isNotNull()
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsentFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsentFundsConfirmation.kt
@@ -2,17 +2,16 @@ package com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.
 
 import assertk.assertThat
 import assertk.assertions.*
-import com.forgerock.securebanking.framework.conditions.Status
-import com.forgerock.securebanking.framework.configuration.psu
+import com.forgerock.securebanking.framework.data.AccessToken
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
-import com.forgerock.uk.openbanking.support.payment.PaymentAS
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
+import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.github.kittinunf.fuel.core.FuelError
-import org.assertj.core.api.Assertions
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5
 import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4
 
@@ -20,33 +19,16 @@ class GetDomesticPaymentsConsentFundsConfirmation(
     val version: OBVersion,
     val tppResource: CreateTppCallback.TppResource
 ) {
-
     private val createDomesticPaymentsConsentsApi = CreateDomesticPaymentsConsents(version, tppResource)
     private val paymentLinks = getPaymentsApiLinks(version)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun shouldGetDomesticPaymentConsentsFundsConfirmation_false() {
         // Given
         val consentRequest = aValidOBWriteDomesticConsent4()
         consentRequest.data.initiation.instructedAmount.amount("1000000")
-        // Given
-        val consent = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsent(consentRequest)
-
-        // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
-            consent.data.consentId,
-            tppResource.tpp.registrationResponse,
-            psu,
-            tppResource.tpp
-        )
-
         // When
-        val result = PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetDomesticPaymentConsentsConsentIdFundsConfirmation,
-                consent.data.consentId
-            ),
-            accessTokenAuthorizationCode
-        )
+        val result = createConsentAndGetFundsConfirmation(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -58,28 +40,18 @@ class GetDomesticPaymentsConsentFundsConfirmation(
 
     fun shouldGetDomesticPaymentConsentsFundsConfirmation_throwsWrongGrantType() {
         // Given
-        val consent = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsent(aValidOBWriteDomesticConsent4())
+        val consentRequest = aValidOBWriteDomesticConsent4()
+        val (consent, _) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
+            consentRequest
+        )
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
+        // client_credentials access token must not allow us to get the funds confirmation
+        val accessTokenClientCredentials = tppResource.tpp.getClientCredentialsAccessToken(
+            defaultPaymentScopesForAccessToken)
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
-                PaymentFactory.urlWithConsentId(
-                    paymentLinks.GetDomesticPaymentConsentsConsentIdFundsConfirmation,
-                    consent.data.consentId
-                ),
-                accessTokenClientCredentials
-            )
+            getFundsConfirmation(consent, accessTokenClientCredentials)
         }
-
         // Then
         assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
@@ -89,30 +61,8 @@ class GetDomesticPaymentsConsentFundsConfirmation(
         // Given
         val consentRequest = aValidOBWriteDomesticConsent4()
         consentRequest.data.initiation.instructedAmount.amount("3")
-        val consent = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsent(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-
-        // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
-            consent.data.consentId,
-            tppResource.tpp.registrationResponse,
-            psu,
-            tppResource.tpp
-        )
-
         // When
-        val result = PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetDomesticPaymentConsentsConsentIdFundsConfirmation,
-                consent.data.consentId
-            ),
-            accessTokenAuthorizationCode
-        )
+        val result = createConsentAndGetFundsConfirmation(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -120,5 +70,24 @@ class GetDomesticPaymentsConsentFundsConfirmation(
         assertThat(result.data.fundsAvailableResult).isNotNull()
         assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
+    }
+
+    private fun createConsentAndGetFundsConfirmation(consentRequest: OBWriteDomesticConsent4): OBWriteFundsConfirmationResponse1 {
+        val (consent, accessTokenAuthorizationCode) = createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentAndAuthorize(
+            consentRequest
+        )
+        return getFundsConfirmation(consent, accessTokenAuthorizationCode)
+    }
+
+    private fun getFundsConfirmation(
+        consent: OBWriteDomesticConsentResponse5,
+        accessTokenAuthorizationCode: AccessToken
+    ): OBWriteFundsConfirmationResponse1 {
+        return paymentApiClient.sendGetRequest(
+            PaymentFactory.urlWithConsentId(
+                paymentLinks.GetDomesticPaymentConsentsConsentIdFundsConfirmation,
+                consent.data.consentId
+            ), accessTokenAuthorizationCode
+        )
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsentFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsentFundsConfirmation.kt
@@ -1,7 +1,10 @@
 package com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.api.v3_1_8
 
 import assertk.assertThat
-import assertk.assertions.*
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotNull
+import assertk.assertions.isTrue
 import com.forgerock.securebanking.framework.data.AccessToken
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsents.kt
@@ -9,10 +9,7 @@ import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
-import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory
 
 class GetDomesticPaymentsConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
@@ -32,14 +29,7 @@ class GetDomesticPaymentsConsents(val version: OBVersion, val tppResource: Creat
         assertThat(consent.risk).isNotNull()
 
         // When
-        val result = PaymentRS().getConsent<OBWriteDomesticConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetDomesticPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
+        val result = createDomesticPaymentsConsentsApi.getPatchedConsent(consent)
 
         // Then
         assertThat(result).isNotNull()
@@ -64,14 +54,7 @@ class GetDomesticPaymentsConsents(val version: OBVersion, val tppResource: Creat
         assertThat(consent.data.initiation.debtorAccount).isNull()
 
         // When
-        val result = PaymentRS().getConsent<OBWriteDomesticConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetDomesticPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
+        val result = createDomesticPaymentsConsentsApi.getPatchedConsent(consent)
 
         // Then
         assertThat(result).isNotNull()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsents.kt
@@ -8,6 +8,7 @@ import assertk.assertions.isNull
 import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
@@ -17,7 +18,8 @@ import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFact
 class GetDomesticPaymentsConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
     private val createDomesticPaymentsConsentsApi = CreateDomesticPaymentsConsents(version, tppResource)
-
+    private val paymentLinks = getPaymentsApiLinks(version)
+    
     fun shouldGetDomesticPaymentsConsents() {
         // Given
         val consentRequest = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4()
@@ -32,7 +34,7 @@ class GetDomesticPaymentsConsents(val version: OBVersion, val tppResource: Creat
         // When
         val result = PaymentRS().getConsent<OBWriteDomesticConsentResponse5>(
             PaymentFactory.urlWithConsentId(
-                createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPaymentConsent,
+                paymentLinks.GetDomesticPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -64,7 +66,7 @@ class GetDomesticPaymentsConsents(val version: OBVersion, val tppResource: Creat
         // When
         val result = PaymentRS().getConsent<OBWriteDomesticConsentResponse5>(
             PaymentFactory.urlWithConsentId(
-                createDomesticPaymentsConsentsApi.paymentLinks.GetDomesticPaymentConsent,
+                paymentLinks.GetDomesticPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/legacy/LegacyGetDomesticPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/legacy/LegacyGetDomesticPaymentsConsentFundsConfirmationTest.kt
@@ -61,7 +61,7 @@ class LegacyGetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: Cre
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -118,7 +118,7 @@ class LegacyGetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: Cre
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -175,7 +175,7 @@ class LegacyGetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: Cre
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         // When
         val exception = assertThrows(AssertionError::class.java) {
@@ -227,7 +227,7 @@ class LegacyGetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: Cre
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -285,7 +285,7 @@ class LegacyGetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: Cre
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -343,7 +343,7 @@ class LegacyGetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: Cre
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         // When
         val exception = assertThrows(AssertionError::class.java) {
@@ -395,7 +395,7 @@ class LegacyGetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: Cre
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -453,7 +453,7 @@ class LegacyGetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: Cre
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -511,7 +511,7 @@ class LegacyGetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: Cre
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         // When
         val exception = assertThrows(AssertionError::class.java) {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/legacy/LegacyCreateDomesticPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/legacy/LegacyCreateDomesticPaymentTest.kt
@@ -68,7 +68,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -150,7 +150,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -232,7 +232,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -310,7 +310,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -385,7 +385,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -470,7 +470,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -554,7 +554,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -644,7 +644,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -735,7 +735,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -819,7 +819,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -905,7 +905,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -983,7 +983,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1058,7 +1058,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1144,7 +1144,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1228,7 +1228,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1312,7 +1312,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1403,7 +1403,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1494,7 +1494,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1578,7 +1578,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1664,7 +1664,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1741,7 +1741,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1816,7 +1816,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1901,7 +1901,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1986,7 +1986,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2071,7 +2071,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2162,7 +2162,7 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/legacy/LegacyGetDomesticPaymentDomesticPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/legacy/LegacyGetDomesticPaymentDomesticPaymentIdPaymentDetailsTest.kt
@@ -58,7 +58,7 @@ class LegacyGetDomesticPaymentDomesticPaymentIdPaymentDetailsTest(val tppResourc
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -66,7 +66,7 @@ class LegacyGetDomesticPaymentDomesticPaymentIdPaymentDetailsTest(val tppResourc
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -157,7 +157,7 @@ class LegacyGetDomesticPaymentDomesticPaymentIdPaymentDetailsTest(val tppResourc
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -165,7 +165,7 @@ class LegacyGetDomesticPaymentDomesticPaymentIdPaymentDetailsTest(val tppResourc
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticConsentResponse3>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/legacy/LegacyGetDomesticPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/legacy/LegacyGetDomesticPaymentTest.kt
@@ -58,7 +58,7 @@ class LegacyGetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResourc
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -66,7 +66,7 @@ class LegacyGetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResourc
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -167,7 +167,7 @@ class LegacyGetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResourc
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -175,7 +175,7 @@ class LegacyGetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResourc
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -276,7 +276,7 @@ class LegacyGetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResourc
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -284,7 +284,7 @@ class LegacyGetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResourc
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -379,7 +379,7 @@ class LegacyGetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResourc
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -387,7 +387,7 @@ class LegacyGetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResourc
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticConsentResponse2>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
@@ -257,17 +257,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
     }
 
     private fun getPatchedConsent(consent: OBWriteDomesticScheduledConsentResponse5): OBWriteDomesticScheduledConsentResponse5 {
-        val patchedConsent = paymentApiClient.getConsent<OBWriteDomesticScheduledConsentResponse5>(
-            paymentLinks.GetDomesticScheduledPaymentConsent,
-            consent.data.consentId,
-            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
-        )
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-        return patchedConsent
+        return createDomesticScheduledPaymentsConsents.getPatchedConsent(consent)
     }
 
     private fun submitPaymentForPatchedConsent(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
@@ -6,24 +6,26 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.conditions.Status
+import com.forgerock.securebanking.framework.data.AccessToken
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.http.fuel.defaultMapper
-import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.framework.constants.INVALID_CONSENT_ID
-import com.forgerock.uk.openbanking.framework.constants.INVALID_FORMAT_DETACHED_JWS
-import com.forgerock.uk.openbanking.framework.constants.INVALID_SIGNING_KID
 import com.forgerock.uk.openbanking.framework.errors.INVALID_FORMAT_DETACHED_JWS_ERROR
 import com.forgerock.uk.openbanking.framework.errors.NO_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.errors.PAYMENT_SUBMISSION_ALREADY_EXISTS
 import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
+import com.forgerock.uk.openbanking.support.payment.BadJwsSignatureProducer
+import com.forgerock.uk.openbanking.support.payment.DefaultJwsSignatureProducer
+import com.forgerock.uk.openbanking.support.payment.InvalidKidJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
+import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.consents.api.v3_1_8.CreateDomesticScheduledPaymentsConsents
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduled2
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduled2Data
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledResponse5
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTestDataFactory
@@ -31,60 +33,19 @@ import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTes
 class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
     private val createDomesticScheduledPaymentsConsents = CreateDomesticScheduledPaymentsConsents(version, tppResource)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
+    private val createPaymentUrl = createDomesticScheduledPaymentsConsents.paymentLinks.CreateDomesticScheduledPayment
 
     fun createDomesticScheduledPaymentsTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.data.initiation).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteDomesticScheduled2().data(
-            OBWriteDomesticScheduled2Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
         // When
-        val result = PaymentRS().submitPayment<OBWriteDomesticScheduledResponse5>(
-            createDomesticScheduledPaymentsConsents.paymentLinks.CreateDomesticScheduledPayment,
-            paymentSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
+        val paymentResponse = submitPayment(consentRequest)
 
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data).isNotNull()
-        assertThat(result.data.consentId).isNotEmpty()
+        assertThat(paymentResponse).isNotNull()
+        assertThat(paymentResponse.data).isNotNull()
+        assertThat(paymentResponse.data.consentId).isNotEmpty()
     }
 
     fun shouldCreateDomesticScheduledPayments_throwsPaymentAlreadyExists() {
@@ -98,50 +59,14 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteDomesticScheduled2().data(
-            OBWriteDomesticScheduled2Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-        val result = PaymentRS().submitPayment<OBWriteDomesticScheduledResponse5>(
-            createDomesticScheduledPaymentsConsents.paymentLinks.CreateDomesticScheduledPayment,
-            paymentSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
+        val patchedConsent = getPatchedConsent(consent)
+        // Submit first payment
+        submitPaymentForPatchedConsent(patchedConsent, accessTokenAuthorizationCode)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPayment<OBWriteDomesticScheduledResponse5>(
-                createDomesticScheduledPaymentsConsents.paymentLinks.CreateDomesticScheduledPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode,
-                signedPayload,
-                tppResource.tpp,
-                version
-            )
+            // Verify we fail to submit a second payment
+            submitPaymentForPatchedConsent(patchedConsent, accessTokenAuthorizationCode)
         }
 
         // Then
@@ -161,38 +86,13 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteDomesticScheduled2().data(
-            OBWriteDomesticScheduled2Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
+        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPayment<OBWriteDomesticScheduledResponse5>(
-                createDomesticScheduledPaymentsConsents.paymentLinks.CreateDomesticScheduledPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode,
-                INVALID_FORMAT_DETACHED_JWS,
-                tppResource.tpp,
-                version
-            )
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessTokenAuthorizationCode, paymentSubmissionRequest)
+                .configureJwsSignatureProducer(BadJwsSignatureProducer()).sendRequest()
         }
-
         // Then
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
         assertThat(exception.message.toString()).contains(INVALID_FORMAT_DETACHED_JWS_ERROR)
@@ -210,34 +110,12 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteDomesticScheduled2().data(
-            OBWriteDomesticScheduled2Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
+        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPaymentNoDetachedJws<OBWriteDomesticScheduledResponse5>(
-                createDomesticScheduledPaymentsConsents.paymentLinks.CreateDomesticScheduledPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode
-            )
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessTokenAuthorizationCode, paymentSubmissionRequest)
+                .configureJwsSignatureProducer(null).sendRequest()
         }
 
         // Then
@@ -257,44 +135,12 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteDomesticScheduled2().data(
-            OBWriteDomesticScheduled2Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(paymentSubmissionRequest),
-                tppResource.tpp.signingKey,
-                tppResource.tpp.signingKid,
-                true
-            )
+        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPayment<OBWriteDomesticScheduledResponse5>(
-                createDomesticScheduledPaymentsConsents.paymentLinks.CreateDomesticScheduledPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode,
-                signedPayload,
-                tppResource.tpp,
-                version
-            )
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessTokenAuthorizationCode, paymentSubmissionRequest)
+                .configureJwsSignatureProducer(DefaultJwsSignatureProducer(tppResource.tpp, false)).sendRequest()
         }
 
         // Then
@@ -314,43 +160,12 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteDomesticScheduled2().data(
-            OBWriteDomesticScheduled2Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(paymentSubmissionRequest),
-                tppResource.tpp.signingKey,
-                INVALID_SIGNING_KID
-            )
+        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPayment<OBWriteDomesticScheduledResponse5>(
-                createDomesticScheduledPaymentsConsents.paymentLinks.CreateDomesticScheduledPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode,
-                signedPayload,
-                tppResource.tpp,
-                version
-            )
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessTokenAuthorizationCode, paymentSubmissionRequest)
+                .configureJwsSignatureProducer(InvalidKidJwsSignatureProducer(tppResource.tpp)).sendRequest()
         }
 
         // Then
@@ -370,49 +185,20 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteDomesticScheduled2().data(
-            OBWriteDomesticScheduled2Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
+        val patchedConsent = getPatchedConsent(consent)
+        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
 
         patchedConsent.data.consentId = INVALID_CONSENT_ID
-        val paymentSubmissionWithInvalidConsentId = OBWriteDomesticScheduled2().data(
-            OBWriteDomesticScheduled2Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
+        val paymentSubmissionWithInvalidConsentId = createPaymentRequest(patchedConsent)
 
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionWithInvalidConsentId),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
+        val signatureWithInvalidConsentId = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
+            defaultMapper.writeValueAsString(paymentSubmissionWithInvalidConsentId)
         )
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPayment<OBWriteDomesticScheduledResponse5>(
-                createDomesticScheduledPaymentsConsents.paymentLinks.CreateDomesticScheduledPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode,
-                signedPayload,
-                tppResource.tpp,
-                version
-            )
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessTokenAuthorizationCode, paymentSubmissionRequest)
+                .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidConsentId)).sendRequest()
         }
 
         // Then
@@ -432,53 +218,73 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteDomesticScheduled2().data(
-            OBWriteDomesticScheduled2Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(PaymentFactory.copyOBWriteDomesticScheduled2DataInitiation(patchedConsent.data.initiation))
-        ).risk(patchedConsent.risk)
+        val patchedConsent = getPatchedConsent(consent)
+        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
 
         patchedConsent.data.initiation.instructedAmount.amount = "123123"
-        val paymentSubmissionInvalidAmount = OBWriteDomesticScheduled2().data(
-            OBWriteDomesticScheduled2Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
+        val paymentSubmissionInvalidAmount = createPaymentRequest(patchedConsent)
 
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionInvalidAmount),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
+        val signatureWithInvalidAmount = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
+            defaultMapper.writeValueAsString(paymentSubmissionInvalidAmount)
         )
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPayment<OBWriteDomesticScheduledResponse5>(
-                createDomesticScheduledPaymentsConsents.paymentLinks.CreateDomesticScheduledPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode,
-                signedPayload,
-                tppResource.tpp,
-                version
-            )
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessTokenAuthorizationCode, paymentSubmissionRequest)
+                .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidAmount)).sendRequest()
         }
 
         // Then
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
         assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+    }
+
+    fun submitPayment(consentRequest: OBWriteDomesticScheduledConsent4): OBWriteDomesticScheduledResponse5 {
+        val (consent, authorizationToken) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
+            consentRequest
+        )
+        return submitPayment(consent, authorizationToken)
+    }
+
+    fun submitPayment(
+        consentResponse: OBWriteDomesticScheduledConsentResponse5,
+        authorizationToken: AccessToken
+    ): OBWriteDomesticScheduledResponse5 {
+        val patchedConsent = getPatchedConsent(consentResponse)
+        return submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
+    }
+
+    private fun getPatchedConsent(consent: OBWriteDomesticScheduledConsentResponse5): OBWriteDomesticScheduledConsentResponse5 {
+        val patchedConsent = paymentApiClient.getConsent<OBWriteDomesticScheduledConsentResponse5>(
+            createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentConsent,
+            consent.data.consentId,
+            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
+        )
+        assertThat(patchedConsent).isNotNull()
+        assertThat(patchedConsent.data).isNotNull()
+        assertThat(patchedConsent.risk).isNotNull()
+        assertThat(patchedConsent.data.consentId).isNotEmpty()
+        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
+        return patchedConsent
+    }
+
+    private fun submitPaymentForPatchedConsent(
+        patchedConsent: OBWriteDomesticScheduledConsentResponse5,
+        authorizationToken: AccessToken
+    ): OBWriteDomesticScheduledResponse5 {
+        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
+        return paymentApiClient.submitPayment(
+            createPaymentUrl,
+            authorizationToken,
+            paymentSubmissionRequest
+        )
+    }
+
+    private fun createPaymentRequest(patchedConsent: OBWriteDomesticScheduledConsentResponse5): OBWriteDomesticScheduled2 {
+        return OBWriteDomesticScheduled2().data(
+            OBWriteDomesticScheduled2Data()
+                .consentId(patchedConsent.data.consentId)
+                .initiation(PaymentFactory.copyOBWriteDomesticScheduled2DataInitiation(patchedConsent.data.initiation))
+        ).risk(patchedConsent.risk)
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
@@ -15,6 +15,7 @@ import com.forgerock.uk.openbanking.framework.errors.INVALID_FORMAT_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.errors.NO_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.errors.PAYMENT_SUBMISSION_ALREADY_EXISTS
 import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.BadJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.DefaultJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.InvalidKidJwsSignatureProducer
@@ -34,7 +35,8 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
 
     private val createDomesticScheduledPaymentsConsents = CreateDomesticScheduledPaymentsConsents(version, tppResource)
     private val paymentApiClient = tppResource.tpp.paymentApiClient
-    private val createPaymentUrl = createDomesticScheduledPaymentsConsents.paymentLinks.CreateDomesticScheduledPayment
+    private val paymentLinks = getPaymentsApiLinks(version)
+    private val createPaymentUrl = paymentLinks.CreateDomesticScheduledPayment
 
     fun createDomesticScheduledPaymentsTest() {
         // Given
@@ -256,7 +258,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
 
     private fun getPatchedConsent(consent: OBWriteDomesticScheduledConsentResponse5): OBWriteDomesticScheduledConsentResponse5 {
         val patchedConsent = paymentApiClient.getConsent<OBWriteDomesticScheduledConsentResponse5>(
-            createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentConsent,
+            paymentLinks.GetDomesticScheduledPaymentConsent,
             consent.data.consentId,
             tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
         )

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
@@ -35,7 +35,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
     fun createDomesticScheduledPaymentsTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndGetAccessToken(
+        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
 
@@ -90,7 +90,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
     fun shouldCreateDomesticScheduledPayments_throwsPaymentAlreadyExists() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndGetAccessToken(
+        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
         assertThat(consent).isNotNull()
@@ -152,7 +152,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
     fun shouldCreateDomesticScheduledPayments_throwsSendInvalidFormatDetachedJws() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndGetAccessToken(
+        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
 
@@ -201,7 +201,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
     fun shouldCreateDomesticScheduledPayments_throwsNoDetachedJwsTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndGetAccessToken(
+        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
 
@@ -248,7 +248,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
     fun shouldCreateDomesticScheduledPayments_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndGetAccessToken(
+        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
 
@@ -305,7 +305,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
     fun shouldCreateDomesticScheduledPayments_throwsSendInvalidKidDetachedJwsTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndGetAccessToken(
+        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
 
@@ -361,7 +361,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
     fun shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBodyTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndGetAccessToken(
+        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
 
@@ -423,7 +423,7 @@ class CreateDomesticScheduledPayment(val version: OBVersion, val tppResource: Cr
     fun shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndGetAccessToken(
+        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/CreateDomesticScheduledPayment.kt
@@ -20,7 +20,6 @@ import com.forgerock.uk.openbanking.support.payment.BadJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.DefaultJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.InvalidKidJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.consents.api.v3_1_8.CreateDomesticScheduledPaymentsConsents
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPayment.kt
@@ -12,7 +12,8 @@ import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.consents.api.v3_1_8.CreateDomesticScheduledPaymentsConsents
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.payment.OBReadRefundAccountEnum
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledResponse5
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTestDataFactory
 
 class GetDomesticScheduledPayment(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPayment.kt
@@ -7,6 +7,7 @@ import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.consents.api.v3_1_8.CreateDomesticScheduledPaymentsConsents
@@ -18,6 +19,7 @@ class GetDomesticScheduledPayment(val version: OBVersion, val tppResource: Creat
 
     private val createDomesticScheduledPaymentsConsents = CreateDomesticScheduledPaymentsConsents(version, tppResource)
     private val createDomesticScheduledPayment = CreateDomesticScheduledPayment(version, tppResource)
+    private val paymentLinks = getPaymentsApiLinks(version)
     private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun getDomesticScheduledPaymentsTest() {
@@ -63,7 +65,7 @@ class GetDomesticScheduledPayment(val version: OBVersion, val tppResource: Creat
 
     private fun getDomesticScheduledPayment(paymentResponse: OBWriteDomesticScheduledResponse5): OBWriteDomesticScheduledResponse5 {
         val getDomesticPaymentUrl = PaymentFactory.urlWithDomesticScheduledPaymentId(
-            createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPayment,
+            paymentLinks.GetDomesticScheduledPayment,
             paymentResponse.data.domesticScheduledPaymentId
         )
         return paymentApiClient.sendGetRequest(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPayment.kt
@@ -23,7 +23,7 @@ class GetDomesticScheduledPayment(val version: OBVersion, val tppResource: Creat
     fun getDomesticScheduledPaymentsTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndGetAccessToken(
+        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
 
@@ -33,7 +33,7 @@ class GetDomesticScheduledPayment(val version: OBVersion, val tppResource: Creat
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -97,7 +97,7 @@ class GetDomesticScheduledPayment(val version: OBVersion, val tppResource: Creat
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
         consentRequest.data.readRefundAccount = OBReadRefundAccountEnum.YES
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndGetAccessToken(
+        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
 
@@ -108,7 +108,7 @@ class GetDomesticScheduledPayment(val version: OBVersion, val tppResource: Creat
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse5>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPayment.kt
@@ -6,11 +6,9 @@ import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
-import com.forgerock.securebanking.framework.http.fuel.defaultMapper
-import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
+import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.consents.api.v3_1_8.CreateDomesticScheduledPaymentsConsents
 import org.assertj.core.api.Assertions
 import uk.org.openbanking.datamodel.payment.*
@@ -19,78 +17,22 @@ import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTes
 class GetDomesticScheduledPayment(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
     private val createDomesticScheduledPaymentsConsents = CreateDomesticScheduledPaymentsConsents(version, tppResource)
+    private val createDomesticScheduledPayment = CreateDomesticScheduledPayment(version, tppResource)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun getDomesticScheduledPaymentsTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteDomesticScheduled2().data(
-            OBWriteDomesticScheduled2Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteDomesticScheduledResponse5>(
-            createDomesticScheduledPaymentsConsents.paymentLinks.CreateDomesticScheduledPayment,
-            paymentSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.domesticScheduledPaymentId).isNotEmpty()
+        val paymentResponse = createDomesticScheduledPayment.submitPayment(consentRequest)
 
         // When
-        val paymentResult = PaymentRS().getPayment<OBWriteDomesticScheduledResponse5>(
-            PaymentFactory.urlWithDomesticScheduledPaymentId(
-                createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPayment,
-                submissionResponse.data.domesticScheduledPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val getPaymentResponse = getDomesticScheduledPayment(paymentResponse)
 
         // Then
-        assertThat(paymentResult).isNotNull()
-        assertThat(paymentResult.data.domesticScheduledPaymentId).isNotEmpty()
-        assertThat(paymentResult.data.creationDateTime).isNotNull()
-        Assertions.assertThat(paymentResult.data.status.toString()).`is`(Status.paymentCondition)
+        assertThat(getPaymentResponse).isNotNull()
+        assertThat(getPaymentResponse.data.domesticScheduledPaymentId).isNotEmpty()
+        assertThat(getPaymentResponse.data.creationDateTime).isNotNull()
+        Assertions.assertThat(getPaymentResponse.data.status.toString()).`is`(Status.paymentCondition)
     }
 
     fun shouldGetDomesticScheduledPayments_withReadRefundTest() {
@@ -107,67 +49,26 @@ class GetDomesticScheduledPayment(val version: OBVersion, val tppResource: Creat
         assertThat(consent.data.readRefundAccount).isEqualTo(OBReadRefundAccountEnum.YES)
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
+        val paymentResponse = createDomesticScheduledPayment.submitPayment(consentRequest)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        assertThat(patchedConsent.data.readRefundAccount).isEqualTo(OBReadRefundAccountEnum.YES)
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteDomesticScheduled2().data(
-            OBWriteDomesticScheduled2Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteDomesticScheduledResponse5>(
-            createDomesticScheduledPaymentsConsents.paymentLinks.CreateDomesticScheduledPayment,
-            paymentSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.domesticScheduledPaymentId).isNotEmpty()
-
-        // When
-        val paymentResult = PaymentRS().getPayment<OBWriteDomesticScheduledResponse5>(
-            PaymentFactory.urlWithDomesticScheduledPaymentId(
-                createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPayment,
-                submissionResponse.data.domesticScheduledPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
-
+        val getPaymentResponse = getDomesticScheduledPayment(paymentResponse)
         // Then
-        assertThat(paymentResult).isNotNull()
-        assertThat(paymentResult.data.domesticScheduledPaymentId).isNotEmpty()
-        assertThat(paymentResult.data.creationDateTime).isNotNull()
+        assertThat(getPaymentResponse).isNotNull()
+        assertThat(getPaymentResponse.data.domesticScheduledPaymentId).isNotEmpty()
+        assertThat(getPaymentResponse.data.creationDateTime).isNotNull()
         //TODO: Waiting for the fix from the issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/241
 //        assertThat(paymentResult.data.refund.account.identification).isEqualTo(consent.data.initiation.debtorAccount.identification)
-        Assertions.assertThat(paymentResult.data.status.toString()).`is`(Status.paymentCondition)
+        Assertions.assertThat(getPaymentResponse.data.status.toString()).`is`(Status.paymentCondition)
+    }
+
+    private fun getDomesticScheduledPayment(paymentResponse: OBWriteDomesticScheduledResponse5): OBWriteDomesticScheduledResponse5 {
+        val getDomesticPaymentUrl = PaymentFactory.urlWithDomesticScheduledPaymentId(
+            createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPayment,
+            paymentResponse.data.domesticScheduledPaymentId
+        )
+        return paymentApiClient.sendGetRequest(
+            getDomesticPaymentUrl,
+            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
+        )
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails.kt
@@ -26,7 +26,7 @@ class GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails(
     fun getDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndGetAccessToken(
+        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
 
@@ -36,7 +36,7 @@ class GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails(
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse5>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails.kt
@@ -1,20 +1,12 @@
 package com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.api.v3_1_8
 
 import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
-import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
-import com.forgerock.securebanking.framework.http.fuel.defaultMapper
-import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
-import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.api.v3_1_8.CreateDomesticPayment
-import com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.consents.api.v3_1_8.CreateDomesticScheduledPaymentsConsents
-import org.assertj.core.api.Assertions
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTestDataFactory
 
@@ -22,9 +14,8 @@ class GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails(
     val version: OBVersion,
     val tppResource: CreateTppCallback.TppResource
 ) {
-
-    private val createDomesticScheduledPaymentsConsents = CreateDomesticScheduledPaymentsConsents(version, tppResource)
     private val createDomesticScheduledPayments = CreateDomesticScheduledPayment(version, tppResource)
+    private val paymentLinks = getPaymentsApiLinks(version)
     private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun getDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest() {
@@ -34,7 +25,7 @@ class GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails(
 
         // When
         val getDomesticPaymentDetailsUrl = PaymentFactory.urlWithDomesticScheduledPaymentId(
-            createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails,
+            paymentLinks.GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails,
             paymentResponse.data.domesticScheduledPaymentId
         )
         val paymentDetailsResponse = paymentApiClient.sendGetRequest<OBWritePaymentDetailsResponse1>(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails.kt
@@ -7,7 +7,7 @@ import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTestDataFactory
 
 class GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/api/v3_1_8/GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails.kt
@@ -11,6 +11,8 @@ import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
+import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.api.v3_1_8.CreateDomesticPayment
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.consents.api.v3_1_8.CreateDomesticScheduledPaymentsConsents
 import org.assertj.core.api.Assertions
 import uk.org.openbanking.datamodel.payment.*
@@ -22,76 +24,27 @@ class GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails(
 ) {
 
     private val createDomesticScheduledPaymentsConsents = CreateDomesticScheduledPaymentsConsents(version, tppResource)
+    private val createDomesticScheduledPayments = CreateDomesticScheduledPayment(version, tppResource)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun getDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-        val (consent, accessTokenAuthorizationCode) = createDomesticScheduledPaymentsConsents.createDomesticScheduledPaymentConsentAndAuthorize(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteDomesticScheduled2().data(
-            OBWriteDomesticScheduled2Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteDomesticScheduledResponse5>(
-            createDomesticScheduledPaymentsConsents.paymentLinks.CreateDomesticScheduledPayment,
-            paymentSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.domesticScheduledPaymentId).isNotEmpty()
+        val paymentResponse = createDomesticScheduledPayments.submitPayment(consentRequest)
 
         // When
-        val paymentResult = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
-            PaymentFactory.urlWithDomesticScheduledPaymentId(
-                createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails,
-                submissionResponse.data.domesticScheduledPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
+        val getDomesticPaymentDetailsUrl = PaymentFactory.urlWithDomesticScheduledPaymentId(
+            createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails,
+            paymentResponse.data.domesticScheduledPaymentId
+        )
+        val paymentDetailsResponse = paymentApiClient.sendGetRequest<OBWritePaymentDetailsResponse1>(
+            getDomesticPaymentDetailsUrl,
+            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
         )
 
         // Then
-        assertThat(paymentResult).isNotNull()
-        assertThat(paymentResult.data).isNotNull()
-        assertThat(paymentResult.data.paymentStatus).isNotNull()
+        assertThat(paymentDetailsResponse).isNotNull()
+        assertThat(paymentDetailsResponse.data).isNotNull()
+        assertThat(paymentDetailsResponse.data.paymentStatus).isNotNull()
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/CreateDomesticScheduledPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/CreateDomesticScheduledPaymentsConsents.kt
@@ -136,4 +136,18 @@ class CreateDomesticScheduledPaymentsConsents(val version: OBVersion, val tppRes
         )
         return consent to accessTokenAuthorizationCode
     }
+
+    fun getPatchedConsent(consent: OBWriteDomesticScheduledConsentResponse5): OBWriteDomesticScheduledConsentResponse5 {
+        val patchedConsent = paymentApiClient.getConsent<OBWriteDomesticScheduledConsentResponse5>(
+            paymentLinks.GetDomesticScheduledPaymentConsent,
+            consent.data.consentId,
+            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
+        )
+        assertThat(patchedConsent).isNotNull()
+        assertThat(patchedConsent.data).isNotNull()
+        assertThat(patchedConsent.risk).isNotNull()
+        assertThat(patchedConsent.data.consentId).isNotEmpty()
+        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
+        return patchedConsent
+    }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/CreateDomesticScheduledPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/CreateDomesticScheduledPaymentsConsents.kt
@@ -120,7 +120,7 @@ class CreateDomesticScheduledPaymentsConsents(val version: OBVersion, val tppRes
 
     private fun buildCreateConsentRequest(
         consent: OBWriteDomesticScheduledConsent4
-    ) = paymentApiClient.createDefaultPostRequest(
+    ) = paymentApiClient.newPostRequestBuilder(
         paymentLinks.CreateDomesticScheduledPaymentConsent,
         tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken),
         consent

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/CreateDomesticScheduledPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/CreateDomesticScheduledPaymentsConsents.kt
@@ -9,18 +9,17 @@ import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.configuration.psu
 import com.forgerock.securebanking.framework.data.AccessToken
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
-import com.forgerock.securebanking.framework.http.fuel.defaultMapper
-import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
-import com.forgerock.uk.openbanking.framework.constants.INVALID_FORMAT_DETACHED_JWS
-import com.forgerock.uk.openbanking.framework.constants.INVALID_SIGNING_KID
 import com.forgerock.uk.openbanking.framework.errors.INVALID_FORMAT_DETACHED_JWS_ERROR
 import com.forgerock.uk.openbanking.framework.errors.NO_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.errors.REQUEST_EXECUTION_TIME_IN_THE_PAST
 import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
+import com.forgerock.uk.openbanking.support.payment.BadJwsSignatureProducer
+import com.forgerock.uk.openbanking.support.payment.DefaultJwsSignatureProducer
+import com.forgerock.uk.openbanking.support.payment.InvalidKidJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.PaymentAS
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
+import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
 import org.joda.time.DateTime
@@ -31,6 +30,7 @@ import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTes
 class CreateDomesticScheduledPaymentsConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
     val paymentLinks = getPaymentsApiLinks(version)
+    val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun createDomesticScheduledPaymentsConsentsTest() {
         // Given
@@ -48,16 +48,9 @@ class CreateDomesticScheduledPaymentsConsents(val version: OBVersion, val tppRes
     fun shouldCreateDomesticScheduledPaymentsConsents_throwsSendInvalidFormatDetachedJwsTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().consent<OBWriteDomesticScheduledConsentResponse5>(
-                paymentLinks.CreateDomesticScheduledPaymentConsent,
-                consentRequest,
-                tppResource.tpp,
-                version,
-                INVALID_FORMAT_DETACHED_JWS
-            )
+            buildCreateConsentRequest(consentRequest).configureJwsSignatureProducer(BadJwsSignatureProducer()).sendRequest()
         }
 
         // Then
@@ -68,15 +61,9 @@ class CreateDomesticScheduledPaymentsConsents(val version: OBVersion, val tppRes
     fun shouldCreateDomesticScheduledPaymentsConsents_throwsNoDetachedJwsTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().consentNoDetachedJwt<OBWriteDomesticScheduledConsentResponse5>(
-                paymentLinks.CreateDomesticScheduledPaymentConsent,
-                consentRequest,
-                tppResource.tpp,
-                version
-            )
+            buildCreateConsentRequest(consentRequest).configureJwsSignatureProducer(null).sendRequest()
         }
 
         // Then
@@ -87,24 +74,9 @@ class CreateDomesticScheduledPaymentsConsents(val version: OBVersion, val tppRes
     fun shouldCreateDomesticScheduledPaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-
-        val signedPayload =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(consentRequest),
-                tppResource.tpp.signingKey,
-                tppResource.tpp.signingKid,
-                true
-            )
-
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().consent<OBWriteDomesticScheduledConsentResponse5>(
-                paymentLinks.CreateDomesticScheduledPaymentConsent,
-                consentRequest,
-                tppResource.tpp,
-                version,
-                signedPayload
-            )
+            buildCreateConsentRequest(consentRequest).configureJwsSignatureProducer(DefaultJwsSignatureProducer(tppResource.tpp, false)).sendRequest()
         }
 
         // Then
@@ -115,23 +87,9 @@ class CreateDomesticScheduledPaymentsConsents(val version: OBVersion, val tppRes
     fun shouldCreateDomesticScheduledPaymentsConsents_throwsSendInvalidKidDetachedJwsTest() {
         // Given
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
-
-        val signedPayloadConsent =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(consentRequest),
-                tppResource.tpp.signingKey,
-                INVALID_SIGNING_KID
-            )
-
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().consent<OBWriteDomesticScheduledConsentResponse5>(
-                paymentLinks.CreateDomesticScheduledPaymentConsent,
-                consentRequest,
-                tppResource.tpp,
-                version,
-                signedPayloadConsent
-            )
+            buildCreateConsentRequest(consentRequest).configureJwsSignatureProducer(InvalidKidJwsSignatureProducer(tppResource.tpp)).sendRequest()
         }
 
         // Then
@@ -144,22 +102,9 @@ class CreateDomesticScheduledPaymentsConsents(val version: OBVersion, val tppRes
         val consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4()
         consentRequest.data.initiation.requestedExecutionDateTime = DateTime.now().minusDays(1)
 
-        val signedPayloadConsent =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(consentRequest),
-                tppResource.tpp.signingKey,
-                INVALID_SIGNING_KID
-            )
-
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().consent<OBWriteDomesticScheduledConsentResponse5>(
-                paymentLinks.CreateDomesticScheduledPaymentConsent,
-                consentRequest,
-                tppResource.tpp,
-                version,
-                signedPayloadConsent
-            )
+            createDomesticScheduledPaymentConsent(consentRequest)
         }
 
         // Then
@@ -167,28 +112,23 @@ class CreateDomesticScheduledPaymentsConsents(val version: OBVersion, val tppRes
         assertThat(exception.message.toString()).contains(REQUEST_EXECUTION_TIME_IN_THE_PAST)
     }
 
-    fun createDomesticScheduledPaymentConsent(consentRequest: OBWriteDomesticScheduledConsent4): OBWriteDomesticScheduledConsentResponse5 {
-        val signedPayloadConsent =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(consentRequest),
-                tppResource.tpp.signingKey,
-                tppResource.tpp.signingKid
-            )
-
-        // When
-        val consent = PaymentRS().consent<OBWriteDomesticScheduledConsentResponse5>(
-            paymentLinks.CreateDomesticScheduledPaymentConsent,
-            consentRequest,
-            tppResource.tpp,
-            version,
-            signedPayloadConsent
-        )
-        return consent
+    fun createDomesticScheduledPaymentConsent(
+        consent: OBWriteDomesticScheduledConsent4,
+    ): OBWriteDomesticScheduledConsentResponse5 {
+        return buildCreateConsentRequest(consent).sendRequest()
     }
 
-    fun createDomesticScheduledPaymentConsentAndGetAccessToken(consentRequest: OBWriteDomesticScheduledConsent4): Pair<OBWriteDomesticScheduledConsentResponse5, AccessToken> {
+    private fun buildCreateConsentRequest(
+        consent: OBWriteDomesticScheduledConsent4
+    ) = paymentApiClient.createDefaultPostRequest(
+        paymentLinks.CreateDomesticScheduledPaymentConsent,
+        tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken),
+        consent
+    )
+
+    fun createDomesticScheduledPaymentConsentAndAuthorize(consentRequest: OBWriteDomesticScheduledConsent4): Pair<OBWriteDomesticScheduledConsentResponse5, AccessToken> {
         val consent = createDomesticScheduledPaymentConsent(consentRequest)
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/CreateDomesticScheduledPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/CreateDomesticScheduledPaymentsConsents.kt
@@ -29,8 +29,8 @@ import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTes
 
 class CreateDomesticScheduledPaymentsConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
-    val paymentLinks = getPaymentsApiLinks(version)
-    val paymentApiClient = tppResource.tpp.paymentApiClient
+    private val paymentLinks = getPaymentsApiLinks(version)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun createDomesticScheduledPaymentsConsentsTest() {
         // Given

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/GetDomesticScheduledPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/GetDomesticScheduledPaymentsConsents.kt
@@ -30,14 +30,7 @@ class GetDomesticScheduledPaymentsConsents(val version: OBVersion, val tppResour
         assertThat(consent.risk).isNotNull()
 
         // When
-        val result = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
+        val result = getConsent(consent.data.consentId)
 
         // Then
         assertThat(result).isNotNull()
@@ -61,14 +54,7 @@ class GetDomesticScheduledPaymentsConsents(val version: OBVersion, val tppResour
         assertThat(consent.data.initiation.debtorAccount).isNull()
 
         // When
-        val result = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
+        val result = getConsent(consent.data.consentId)
 
         // Then
         assertThat(result).isNotNull()
@@ -77,5 +63,14 @@ class GetDomesticScheduledPaymentsConsents(val version: OBVersion, val tppResour
         assertThat(result.data).isEqualTo(consent.data)
         assertThat(result.risk).isEqualTo(consent.risk)
         assertThat(result.data.initiation.debtorAccount).isNull()
+    }
+
+    private fun getConsent(consentId: String): OBWriteDomesticScheduledConsentResponse5 {
+        return createDomesticScheduledPaymentsConsents.paymentApiClient.sendGetRequest<OBWriteDomesticScheduledConsentResponse5>(
+            PaymentFactory.urlWithConsentId(
+                createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentConsent,
+                consentId
+            ), PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
+        )
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/GetDomesticScheduledPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/GetDomesticScheduledPaymentsConsents.kt
@@ -8,6 +8,7 @@ import assertk.assertions.isNull
 import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
@@ -16,7 +17,9 @@ import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTes
 
 class GetDomesticScheduledPaymentsConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
-    val createDomesticScheduledPaymentsConsents = CreateDomesticScheduledPaymentsConsents(version, tppResource)
+    private val createDomesticScheduledPaymentsConsents = CreateDomesticScheduledPaymentsConsents(version, tppResource)
+    private val paymentLinks = getPaymentsApiLinks(version)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun shouldGetDomesticScheduledPaymentsConsentsTest() {
         // Given
@@ -66,9 +69,9 @@ class GetDomesticScheduledPaymentsConsents(val version: OBVersion, val tppResour
     }
 
     private fun getConsent(consentId: String): OBWriteDomesticScheduledConsentResponse5 {
-        return createDomesticScheduledPaymentsConsents.paymentApiClient.sendGetRequest<OBWriteDomesticScheduledConsentResponse5>(
+        return paymentApiClient.sendGetRequest<OBWriteDomesticScheduledConsentResponse5>(
             PaymentFactory.urlWithConsentId(
-                createDomesticScheduledPaymentsConsents.paymentLinks.GetDomesticScheduledPaymentConsent,
+                paymentLinks.GetDomesticScheduledPaymentConsent,
                 consentId
             ), PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
         )

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/GetDomesticScheduledPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/api/v3_1_8/GetDomesticScheduledPaymentsConsents.kt
@@ -8,18 +8,12 @@ import assertk.assertions.isNull
 import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
-import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
-import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTestDataFactory
 
 class GetDomesticScheduledPaymentsConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
     private val createDomesticScheduledPaymentsConsents = CreateDomesticScheduledPaymentsConsents(version, tppResource)
-    private val paymentLinks = getPaymentsApiLinks(version)
-    private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun shouldGetDomesticScheduledPaymentsConsentsTest() {
         // Given
@@ -33,7 +27,7 @@ class GetDomesticScheduledPaymentsConsents(val version: OBVersion, val tppResour
         assertThat(consent.risk).isNotNull()
 
         // When
-        val result = getConsent(consent.data.consentId)
+        val result = createDomesticScheduledPaymentsConsents.getPatchedConsent(consent)
 
         // Then
         assertThat(result).isNotNull()
@@ -57,7 +51,7 @@ class GetDomesticScheduledPaymentsConsents(val version: OBVersion, val tppResour
         assertThat(consent.data.initiation.debtorAccount).isNull()
 
         // When
-        val result = getConsent(consent.data.consentId)
+        val result = createDomesticScheduledPaymentsConsents.getPatchedConsent(consent)
 
         // Then
         assertThat(result).isNotNull()
@@ -66,14 +60,5 @@ class GetDomesticScheduledPaymentsConsents(val version: OBVersion, val tppResour
         assertThat(result.data).isEqualTo(consent.data)
         assertThat(result.risk).isEqualTo(consent.risk)
         assertThat(result.data.initiation.debtorAccount).isNull()
-    }
-
-    private fun getConsent(consentId: String): OBWriteDomesticScheduledConsentResponse5 {
-        return paymentApiClient.sendGetRequest<OBWriteDomesticScheduledConsentResponse5>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetDomesticScheduledPaymentConsent,
-                consentId
-            ), PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-        )
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/legacy/LegacyCreateDomesticScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/legacy/LegacyCreateDomesticScheduledPaymentTest.kt
@@ -69,7 +69,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -152,7 +152,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -241,7 +241,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -319,7 +319,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -394,7 +394,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -479,7 +479,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -563,7 +563,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -653,7 +653,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -744,7 +744,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -829,7 +829,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -922,7 +922,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1000,7 +1000,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1075,7 +1075,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1161,7 +1161,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1245,7 +1245,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1329,7 +1329,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1420,7 +1420,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1511,7 +1511,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1596,7 +1596,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1689,7 +1689,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1766,7 +1766,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1841,7 +1841,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1926,7 +1926,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2011,7 +2011,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2096,7 +2096,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2187,7 +2187,7 @@ class LegacyCreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallbac
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/legacy/LegacyGetDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/legacy/LegacyGetDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest.kt
@@ -56,7 +56,7 @@ class LegacyGetDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest(val t
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -64,7 +64,7 @@ class LegacyGetDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest(val t
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -155,7 +155,7 @@ class LegacyGetDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest(val t
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -163,7 +163,7 @@ class LegacyGetDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest(val t
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse3>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/legacy/LegacyGetDomesticScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/legacy/LegacyGetDomesticScheduledPaymentTest.kt
@@ -57,7 +57,7 @@ class LegacyGetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -65,7 +65,7 @@ class LegacyGetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.T
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -166,7 +166,7 @@ class LegacyGetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -174,7 +174,7 @@ class LegacyGetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.T
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -275,7 +275,7 @@ class LegacyGetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -283,7 +283,7 @@ class LegacyGetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.T
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -378,7 +378,7 @@ class LegacyGetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -386,7 +386,7 @@ class LegacyGetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.T
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticScheduledConsentResponse2>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
@@ -15,6 +15,7 @@ import com.forgerock.uk.openbanking.framework.errors.INVALID_FORMAT_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.errors.NO_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.errors.PAYMENT_SUBMISSION_ALREADY_EXISTS
 import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.BadJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.DefaultJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.InvalidKidJwsSignatureProducer
@@ -36,7 +37,8 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
 
     private val createDomesticStandingOrderConsentsApi = CreateDomesticStandingOrderConsents(version, tppResource)
     private val paymentApiClient = tppResource.tpp.paymentApiClient
-    private val createPaymentUrl = createDomesticStandingOrderConsentsApi.paymentLinks.CreateDomesticStandingOrder
+    private val paymentLinks = getPaymentsApiLinks(version)
+    private val createPaymentUrl = paymentLinks.CreateDomesticStandingOrder
 
     fun createDomesticStandingOrderTest() {
         // Given
@@ -134,7 +136,7 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createDomesticStandingOrderConsentsApi.paymentLinks.GetDomesticStandingOrderConsent,
+                paymentLinks.GetDomesticStandingOrderConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -297,7 +299,7 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
 
     private fun getPatchedConsent(consent: OBWriteDomesticStandingOrderConsentResponse6): OBWriteDomesticStandingOrderConsentResponse6 {
         val patchedConsent = paymentApiClient.getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
-            createDomesticStandingOrderConsentsApi.paymentLinks.GetDomesticStandingOrderConsent,
+            paymentLinks.GetDomesticStandingOrderConsent,
             consent.data.consentId,
             tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
         )

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
@@ -19,10 +19,7 @@ import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.BadJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.DefaultJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.InvalidKidJwsSignatureProducer
-import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.copyOBWriteDomesticStandingOrder3DataInitiation
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
-import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.consents.api.v3_1_8.CreateDomesticStandingOrderConsents
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
@@ -133,21 +130,6 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
         assertThat(consent.data).isNotNull()
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetDomesticStandingOrderConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = createStandingOrderRequest(getPatchedConsent(consent))
 
@@ -298,17 +280,7 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
     }
 
     private fun getPatchedConsent(consent: OBWriteDomesticStandingOrderConsentResponse6): OBWriteDomesticStandingOrderConsentResponse6 {
-        val patchedConsent = paymentApiClient.getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
-            paymentLinks.GetDomesticStandingOrderConsent,
-            consent.data.consentId,
-            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
-        )
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-        return patchedConsent
+        return createDomesticStandingOrderConsentsApi.getPatchedConsent(consent)
     }
 
     private fun submitStandingOrderForPatchedConsent(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrder.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrder.kt
@@ -7,6 +7,7 @@ import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.consents.api.v3_1_8.CreateDomesticStandingOrderConsents
@@ -18,6 +19,7 @@ class GetDomesticStandingOrder(val version: OBVersion, val tppResource: CreateTp
 
     private val createDomesticStandingOrderConsentsApi = CreateDomesticStandingOrderConsents(version, tppResource)
     private val createDomesticStandingOrderApi = CreateDomesticStandingOrder(version, tppResource)
+    private val paymentLinks = getPaymentsApiLinks(version)
     private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun getDomesticStandingOrdersTest() {
@@ -83,7 +85,7 @@ class GetDomesticStandingOrder(val version: OBVersion, val tppResource: CreateTp
 
     private fun getStandingOrder(standingOrderResponse: OBWriteDomesticStandingOrderResponse6): OBWriteDomesticStandingOrderResponse6 {
         val getDomesticPaymentUrl = PaymentFactory.urlWithDomesticStandingOrderId(
-            createDomesticStandingOrderConsentsApi.paymentLinks.GetDomesticStandingOrder,
+            paymentLinks.GetDomesticStandingOrder,
             standingOrderResponse.data.domesticStandingOrderId
         )
         return paymentApiClient.sendGetRequest(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrder.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrder.kt
@@ -12,7 +12,8 @@ import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.consents.api.v3_1_8.CreateDomesticStandingOrderConsents
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.payment.OBReadRefundAccountEnum
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderResponse6
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsentTestDataFactory
 
 class GetDomesticStandingOrder(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrder.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrder.kt
@@ -33,7 +33,7 @@ class GetDomesticStandingOrder(val version: OBVersion, val tppResource: CreateTp
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
             PaymentFactory.urlWithConsentId(
@@ -107,7 +107,7 @@ class GetDomesticStandingOrder(val version: OBVersion, val tppResource: CreateTp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
             PaymentFactory.urlWithConsentId(
@@ -183,7 +183,7 @@ class GetDomesticStandingOrder(val version: OBVersion, val tppResource: CreateTp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrder.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrder.kt
@@ -6,11 +6,9 @@ import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
-import com.forgerock.securebanking.framework.http.fuel.defaultMapper
-import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
+import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.consents.api.v3_1_8.CreateDomesticStandingOrderConsents
 import org.assertj.core.api.Assertions
 import uk.org.openbanking.datamodel.payment.*
@@ -19,152 +17,39 @@ import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsen
 class GetDomesticStandingOrder(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
     private val createDomesticStandingOrderConsentsApi = CreateDomesticStandingOrderConsents(version, tppResource)
+    private val createDomesticStandingOrderApi = CreateDomesticStandingOrder(version, tppResource)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun getDomesticStandingOrdersTest() {
         // Given
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5()
-        val (consent, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndGetAccessToken(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticStandingOrderConsentsApi.paymentLinks.GetDomesticStandingOrderConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteDomesticStandingOrder3().data(
-            OBWriteDomesticStandingOrder3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteDomesticStandingOrderResponse6>(
-            createDomesticStandingOrderConsentsApi.paymentLinks.CreateDomesticStandingOrder,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.domesticStandingOrderId).isNotEmpty()
+        val standingOrderResponse = createDomesticStandingOrderApi.submitStandingOrder(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWriteDomesticStandingOrderResponse6>(
-            PaymentFactory.urlWithDomesticStandingOrderId(
-                createDomesticStandingOrderConsentsApi.paymentLinks.GetDomesticStandingOrder,
-                submissionResponse.data.domesticStandingOrderId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val getStandingOrderResponse = getStandingOrder(standingOrderResponse)
 
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data.domesticStandingOrderId).isNotEmpty()
-        assertThat(result.data.creationDateTime).isNotNull()
-        Assertions.assertThat(result.data.status.toString()).`is`(Status.paymentCondition)
+        assertThat(getStandingOrderResponse).isNotNull()
+        assertThat(getStandingOrderResponse.data.domesticStandingOrderId).isNotEmpty()
+        assertThat(getStandingOrderResponse.data.creationDateTime).isNotNull()
+        Assertions.assertThat(getStandingOrderResponse.data.status.toString()).`is`(Status.paymentCondition)
     }
 
     fun getDomesticStandingOrders_mandatoryFieldsTest() {
         // Given
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5MandatoryFields()
-        val (consent, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndGetAccessToken(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticStandingOrderConsentsApi.paymentLinks.GetDomesticStandingOrderConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteDomesticStandingOrder3().data(
-            OBWriteDomesticStandingOrder3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteDomesticStandingOrderResponse6>(
-            createDomesticStandingOrderConsentsApi.paymentLinks.CreateDomesticStandingOrder,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.domesticStandingOrderId).isNotEmpty()
+        val standingOrderResponse = createDomesticStandingOrderApi.submitStandingOrder(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWriteDomesticStandingOrderResponse6>(
-            PaymentFactory.urlWithDomesticStandingOrderId(
-                createDomesticStandingOrderConsentsApi.paymentLinks.GetDomesticStandingOrder,
-                submissionResponse.data.domesticStandingOrderId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val getStandingOrderResponse = getStandingOrder(standingOrderResponse)
 
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data.domesticStandingOrderId).isNotEmpty()
-        assertThat(result.data.creationDateTime).isNotNull()
-        Assertions.assertThat(result.data.status.toString()).`is`(Status.paymentCondition)
+        assertThat(getStandingOrderResponse).isNotNull()
+        assertThat(getStandingOrderResponse.data.domesticStandingOrderId).isNotEmpty()
+        assertThat(getStandingOrderResponse.data.creationDateTime).isNotNull()
+        Assertions.assertThat(getStandingOrderResponse.data.status.toString()).`is`(Status.paymentCondition)
     }
 
     fun shouldGetDomesticStandingOrders_withReadRefundTest() {
@@ -172,7 +57,7 @@ class GetDomesticStandingOrder(val version: OBVersion, val tppResource: CreateTp
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5()
         consentRequest.data.readRefundAccount = OBReadRefundAccountEnum.YES
-        val (consent, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndGetAccessToken(
+        val (consent, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
             consentRequest
         )
 
@@ -182,68 +67,28 @@ class GetDomesticStandingOrder(val version: OBVersion, val tppResource: CreateTp
         assertThat(consent.data.readRefundAccount).isEqualTo(OBReadRefundAccountEnum.YES)
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticStandingOrderConsentsApi.paymentLinks.GetDomesticStandingOrderConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        assertThat(patchedConsent.data.readRefundAccount).isEqualTo(OBReadRefundAccountEnum.YES)
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteDomesticStandingOrder3().data(
-            OBWriteDomesticStandingOrder3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteDomesticStandingOrderResponse6>(
-            createDomesticStandingOrderConsentsApi.paymentLinks.CreateDomesticStandingOrder,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.domesticStandingOrderId).isNotEmpty()
+        val standingOrderResponse = createDomesticStandingOrderApi.submitStandingOrder(consent, accessTokenAuthorizationCode)
 
         // When
-        val result = PaymentRS().getPayment<OBWriteDomesticStandingOrderResponse6>(
-            PaymentFactory.urlWithDomesticStandingOrderId(
-                createDomesticStandingOrderConsentsApi.paymentLinks.GetDomesticStandingOrder,
-                submissionResponse.data.domesticStandingOrderId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val getStandingOrderResponse = getStandingOrder(standingOrderResponse)
 
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data.domesticStandingOrderId).isNotEmpty()
-        assertThat(result.data.creationDateTime).isNotNull()
+        assertThat(getStandingOrderResponse).isNotNull()
+        assertThat(getStandingOrderResponse.data.domesticStandingOrderId).isNotEmpty()
+        assertThat(getStandingOrderResponse.data.creationDateTime).isNotNull()
         //TODO: Waiting for the fix from the issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/241
 //        assertThat(result.data.refund.account.identification).isEqualTo(consent.data.initiation.debtorAccount.identification)
-        Assertions.assertThat(result.data.status.toString()).`is`(Status.paymentCondition)
+        Assertions.assertThat(getStandingOrderResponse.data.status.toString()).`is`(Status.paymentCondition)
     }
 
+    private fun getStandingOrder(standingOrderResponse: OBWriteDomesticStandingOrderResponse6): OBWriteDomesticStandingOrderResponse6 {
+        val getDomesticPaymentUrl = PaymentFactory.urlWithDomesticStandingOrderId(
+            createDomesticStandingOrderConsentsApi.paymentLinks.GetDomesticStandingOrder,
+            standingOrderResponse.data.domesticStandingOrderId
+        )
+        return paymentApiClient.sendGetRequest(
+            getDomesticPaymentUrl,
+            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
+        )
+    }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.consents.api.v3_1_8.CreateDomesticStandingOrderConsents
@@ -14,9 +15,8 @@ class GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails(
     val version: OBVersion,
     val tppResource: CreateTppCallback.TppResource
 ) {
-
-    private val createDomesticStandingOrderConsentsApi = CreateDomesticStandingOrderConsents(version, tppResource)
     private val createDomesticStandingOrderApi = CreateDomesticStandingOrder(version, tppResource)
+    private val paymentLinks = getPaymentsApiLinks(version)
     private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun getDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest() {
@@ -51,7 +51,7 @@ class GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails(
 
     private fun getDomesticStandingOrderPaymentDetails(standingOrderResponse: OBWriteDomesticStandingOrderResponse6): OBWritePaymentDetailsResponse1 {
         val getDomesticStandingOrderDetailsUrl = PaymentFactory.urlWithDomesticStandingOrderId(
-            createDomesticStandingOrderConsentsApi.paymentLinks.GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails,
+            paymentLinks.GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails,
             standingOrderResponse.data.domesticStandingOrderId
         )
         return paymentApiClient.sendGetRequest<OBWritePaymentDetailsResponse1>(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails.kt
@@ -27,7 +27,7 @@ class GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails(
         // Given
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5()
-        val (consent, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndGetAccessToken(
+        val (consent, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
             consentRequest
         )
 
@@ -100,7 +100,7 @@ class GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails(
         // Given
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5MandatoryFields()
-        val (consent, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndGetAccessToken(
+        val (consent, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
             consentRequest
         )
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails.kt
@@ -37,7 +37,7 @@ class GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails(
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
             PaymentFactory.urlWithConsentId(
@@ -110,7 +110,7 @@ class GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails(
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails.kt
@@ -1,18 +1,12 @@
 package com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.api.v3_1_8
 
 import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
-import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
-import com.forgerock.securebanking.framework.http.fuel.defaultMapper
-import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
+import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.consents.api.v3_1_8.CreateDomesticStandingOrderConsents
-import org.assertj.core.api.Assertions
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsentTestDataFactory
 
@@ -22,151 +16,47 @@ class GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails(
 ) {
 
     private val createDomesticStandingOrderConsentsApi = CreateDomesticStandingOrderConsents(version, tppResource)
+    private val createDomesticStandingOrderApi = CreateDomesticStandingOrder(version, tppResource)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun getDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest() {
         // Given
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5()
-        val (consent, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticStandingOrderConsentsApi.paymentLinks.GetDomesticStandingOrderConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteDomesticStandingOrder3().data(
-            OBWriteDomesticStandingOrder3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteDomesticStandingOrderResponse6>(
-            createDomesticStandingOrderConsentsApi.paymentLinks.CreateDomesticStandingOrder,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.domesticStandingOrderId).isNotEmpty()
+        val standingOrderResponse = createDomesticStandingOrderApi.submitStandingOrder(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
-            PaymentFactory.urlWithDomesticStandingOrderId(
-                createDomesticStandingOrderConsentsApi.paymentLinks.GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails,
-                submissionResponse.data.domesticStandingOrderId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val domesticStandingOrderDetails = getDomesticStandingOrderPaymentDetails(standingOrderResponse)
 
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data).isNotNull()
-        assertThat(result.data.paymentStatus).isNotNull()
+        assertThat(domesticStandingOrderDetails).isNotNull()
+        assertThat(domesticStandingOrderDetails.data).isNotNull()
+        assertThat(domesticStandingOrderDetails.data.paymentStatus).isNotNull()
     }
 
     fun getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails_mandatoryFieldsTest() {
         // Given
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5MandatoryFields()
-        val (consent, accessTokenAuthorizationCode) = createDomesticStandingOrderConsentsApi.createDomesticStandingOrderConsentAndAuthorize(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                createDomesticStandingOrderConsentsApi.paymentLinks.GetDomesticStandingOrderConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteDomesticStandingOrder3().data(
-            OBWriteDomesticStandingOrder3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteDomesticStandingOrderResponse6>(
-            createDomesticStandingOrderConsentsApi.paymentLinks.CreateDomesticStandingOrder,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.domesticStandingOrderId).isNotEmpty()
+        val standingOrderResponse = createDomesticStandingOrderApi.submitStandingOrder(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
-            PaymentFactory.urlWithDomesticStandingOrderId(
-                createDomesticStandingOrderConsentsApi.paymentLinks.GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails,
-                submissionResponse.data.domesticStandingOrderId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val domesticStandingOrderDetails = getDomesticStandingOrderPaymentDetails(standingOrderResponse)
 
         // Then
-        assertThat(result).isNotNull()
-        assertThat(result.data).isNotNull()
-        assertThat(result.data.paymentStatus).isNotNull()
+        assertThat(domesticStandingOrderDetails).isNotNull()
+        assertThat(domesticStandingOrderDetails.data).isNotNull()
+        assertThat(domesticStandingOrderDetails.data.paymentStatus).isNotNull()
     }
 
+    private fun getDomesticStandingOrderPaymentDetails(standingOrderResponse: OBWriteDomesticStandingOrderResponse6): OBWritePaymentDetailsResponse1 {
+        val getDomesticStandingOrderDetailsUrl = PaymentFactory.urlWithDomesticStandingOrderId(
+            createDomesticStandingOrderConsentsApi.paymentLinks.GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails,
+            standingOrderResponse.data.domesticStandingOrderId
+        )
+        return paymentApiClient.sendGetRequest<OBWritePaymentDetailsResponse1>(
+            getDomesticStandingOrderDetailsUrl,
+            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
+        )
+    }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails.kt
@@ -7,8 +7,8 @@ import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
-import com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.consents.api.v3_1_8.CreateDomesticStandingOrderConsents
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderResponse6
+import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsentTestDataFactory
 
 class GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/CreateDomesticStandingOrderConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/CreateDomesticStandingOrderConsents.kt
@@ -29,7 +29,7 @@ import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsen
 
 class CreateDomesticStandingOrderConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
-    val paymentLinks = getPaymentsApiLinks(version)
+    private val paymentLinks = getPaymentsApiLinks(version)
     private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun createDomesticStandingOrdersConsentsTest() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/CreateDomesticStandingOrderConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/CreateDomesticStandingOrderConsents.kt
@@ -148,7 +148,7 @@ class CreateDomesticStandingOrderConsents(val version: OBVersion, val tppResourc
         consent
     )
 
-    fun createDomesticStandingOrderConsentAndGetAccessToken(consentRequest: OBWriteDomesticStandingOrderConsent5): Pair<OBWriteDomesticStandingOrderConsentResponse6, AccessToken> {
+    fun createDomesticStandingOrderConsentAndAuthorize(consentRequest: OBWriteDomesticStandingOrderConsent5): Pair<OBWriteDomesticStandingOrderConsentResponse6, AccessToken> {
         val consent = createDomesticStandingOrderConsent(consentRequest)
         val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/CreateDomesticStandingOrderConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/CreateDomesticStandingOrderConsents.kt
@@ -9,20 +9,18 @@ import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.configuration.psu
 import com.forgerock.securebanking.framework.data.AccessToken
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
-import com.forgerock.securebanking.framework.http.fuel.defaultMapper
-import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
-import com.forgerock.uk.openbanking.framework.constants.INVALID_FORMAT_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.constants.INVALID_FREQUENCY
-import com.forgerock.uk.openbanking.framework.constants.INVALID_SIGNING_KID
 import com.forgerock.uk.openbanking.framework.errors.INVALID_FORMAT_DETACHED_JWS_ERROR
 import com.forgerock.uk.openbanking.framework.errors.INVALID_FREQUENCY_VALUE
 import com.forgerock.uk.openbanking.framework.errors.NO_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
-import com.forgerock.uk.openbanking.support.discovery.payment3_1_8
+import com.forgerock.uk.openbanking.support.payment.BadJwsSignatureProducer
+import com.forgerock.uk.openbanking.support.payment.DefaultJwsSignatureProducer
+import com.forgerock.uk.openbanking.support.payment.InvalidKidJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.PaymentAS
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
+import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5
@@ -32,6 +30,7 @@ import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsen
 class CreateDomesticStandingOrderConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
     val paymentLinks = getPaymentsApiLinks(version)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun createDomesticStandingOrdersConsentsTest() {
         // Given
@@ -66,22 +65,10 @@ class CreateDomesticStandingOrderConsents(val version: OBVersion, val tppResourc
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5()
         consentRequest.data.initiation.frequency = INVALID_FREQUENCY
-        val signedPayloadConsent =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(consentRequest),
-                tppResource.tpp.signingKey,
-                tppResource.tpp.signingKid
-            )
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse6>(
-                paymentLinks.CreateDomesticStandingOrderConsent,
-                consentRequest,
-                tppResource.tpp,
-                version,
-                signedPayloadConsent
-            )
+            createDomesticStandingOrderConsent(consentRequest)
         }
 
         // Then
@@ -96,13 +83,7 @@ class CreateDomesticStandingOrderConsents(val version: OBVersion, val tppResourc
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse6>(
-                paymentLinks.CreateDomesticStandingOrderConsent,
-                consentRequest,
-                tppResource.tpp,
-                version,
-                INVALID_FORMAT_DETACHED_JWS
-            )
+            buildCreateConsentRequest(consentRequest).configureJwsSignatureProducer(BadJwsSignatureProducer()).sendRequest()
         }
 
         // Then
@@ -117,12 +98,7 @@ class CreateDomesticStandingOrderConsents(val version: OBVersion, val tppResourc
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().consentNoDetachedJwt<OBWriteDomesticStandingOrderConsentResponse6>(
-                paymentLinks.CreateDomesticStandingOrderConsent,
-                consentRequest,
-                tppResource.tpp,
-                version
-            )
+            buildCreateConsentRequest(consentRequest).configureJwsSignatureProducer(null).sendRequest()
         }
 
         // Then
@@ -135,23 +111,9 @@ class CreateDomesticStandingOrderConsents(val version: OBVersion, val tppResourc
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5()
 
-        val signedPayload =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(consentRequest),
-                tppResource.tpp.signingKey,
-                tppResource.tpp.signingKid,
-                true
-            )
-
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse6>(
-                paymentLinks.CreateDomesticStandingOrderConsent,
-                consentRequest,
-                tppResource.tpp,
-                version,
-                signedPayload
-            )
+            buildCreateConsentRequest(consentRequest).configureJwsSignatureProducer(DefaultJwsSignatureProducer(tppResource.tpp, false)).sendRequest()
         }
 
         // Then
@@ -164,22 +126,9 @@ class CreateDomesticStandingOrderConsents(val version: OBVersion, val tppResourc
         val consentRequest =
             OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent5()
 
-        val signedPayloadConsent =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(consentRequest),
-                tppResource.tpp.signingKey,
-                INVALID_SIGNING_KID
-            )
-
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse6>(
-                paymentLinks.CreateDomesticStandingOrderConsent,
-                consentRequest,
-                tppResource.tpp,
-                version,
-                signedPayloadConsent
-            )
+            buildCreateConsentRequest(consentRequest).configureJwsSignatureProducer(InvalidKidJwsSignatureProducer(tppResource.tpp)).sendRequest()
         }
 
         // Then
@@ -188,27 +137,20 @@ class CreateDomesticStandingOrderConsents(val version: OBVersion, val tppResourc
     }
 
     fun createDomesticStandingOrderConsent(consentRequest: OBWriteDomesticStandingOrderConsent5): OBWriteDomesticStandingOrderConsentResponse6 {
-        val signedPayloadConsent =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(consentRequest),
-                tppResource.tpp.signingKey,
-                tppResource.tpp.signingKid
-            )
-
-        // When
-        val consent = PaymentRS().consent<OBWriteDomesticStandingOrderConsentResponse6>(
-            paymentLinks.CreateDomesticStandingOrderConsent,
-            consentRequest,
-            tppResource.tpp,
-            version,
-            signedPayloadConsent
-        )
-        return consent
+        return buildCreateConsentRequest(consentRequest).sendRequest()
     }
+
+    private fun buildCreateConsentRequest(
+        consent: OBWriteDomesticStandingOrderConsent5
+    ) = paymentApiClient.createDefaultPostRequest(
+        paymentLinks.CreateDomesticStandingOrderConsent,
+        tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken),
+        consent
+    )
 
     fun createDomesticStandingOrderConsentAndGetAccessToken(consentRequest: OBWriteDomesticStandingOrderConsent5): Pair<OBWriteDomesticStandingOrderConsentResponse6, AccessToken> {
         val consent = createDomesticStandingOrderConsent(consentRequest)
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/CreateDomesticStandingOrderConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/CreateDomesticStandingOrderConsents.kt
@@ -158,4 +158,18 @@ class CreateDomesticStandingOrderConsents(val version: OBVersion, val tppResourc
         )
         return consent to accessTokenAuthorizationCode
     }
+
+    fun getPatchedConsent(consent: OBWriteDomesticStandingOrderConsentResponse6): OBWriteDomesticStandingOrderConsentResponse6 {
+        val patchedConsent = paymentApiClient.getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
+            paymentLinks.GetDomesticStandingOrderConsent,
+            consent.data.consentId,
+            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
+        )
+        assertThat(patchedConsent).isNotNull()
+        assertThat(patchedConsent.data).isNotNull()
+        assertThat(patchedConsent.risk).isNotNull()
+        assertThat(patchedConsent.data.consentId).isNotEmpty()
+        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
+        return patchedConsent
+    }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/CreateDomesticStandingOrderConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/CreateDomesticStandingOrderConsents.kt
@@ -142,7 +142,7 @@ class CreateDomesticStandingOrderConsents(val version: OBVersion, val tppResourc
 
     private fun buildCreateConsentRequest(
         consent: OBWriteDomesticStandingOrderConsent5
-    ) = paymentApiClient.createDefaultPostRequest(
+    ) = paymentApiClient.newPostRequestBuilder(
         paymentLinks.CreateDomesticStandingOrderConsent,
         tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken),
         consent

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/GetDomesticStandingOrderConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/GetDomesticStandingOrderConsents.kt
@@ -7,6 +7,7 @@ import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
@@ -16,6 +17,7 @@ import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsen
 class GetDomesticStandingOrderConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
     private val createDomesticStandingOrderConsentsApi = CreateDomesticStandingOrderConsents(version, tppResource)
+    private val paymentLinks = getPaymentsApiLinks(version)
 
     fun shouldGetDomesticStandingOrdersConsents_Test() {
         // Given
@@ -33,7 +35,7 @@ class GetDomesticStandingOrderConsents(val version: OBVersion, val tppResource: 
         // When
         val result = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createDomesticStandingOrderConsentsApi.paymentLinks.GetDomesticStandingOrderConsent,
+                paymentLinks.GetDomesticStandingOrderConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/GetDomesticStandingOrderConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/api/v3_1_8/GetDomesticStandingOrderConsents.kt
@@ -7,17 +7,12 @@ import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
-import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
-import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse6
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsentTestDataFactory
 
 class GetDomesticStandingOrderConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
     private val createDomesticStandingOrderConsentsApi = CreateDomesticStandingOrderConsents(version, tppResource)
-    private val paymentLinks = getPaymentsApiLinks(version)
 
     fun shouldGetDomesticStandingOrdersConsents_Test() {
         // Given
@@ -33,14 +28,7 @@ class GetDomesticStandingOrderConsents(val version: OBVersion, val tppResource: 
         assertThat(consent.risk).isNotNull()
 
         // When
-        val result = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetDomesticStandingOrderConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
+        val result = createDomesticStandingOrderConsentsApi.getPatchedConsent(consent)
 
         // Then
         assertThat(result).isNotNull()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/legacy/LegacyCreateDomesticStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/legacy/LegacyCreateDomesticStandingOrderTest.kt
@@ -69,7 +69,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -151,7 +151,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -234,7 +234,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -323,7 +323,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -401,7 +401,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -476,7 +476,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -561,7 +561,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -645,7 +645,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -735,7 +735,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -826,7 +826,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -910,7 +910,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -995,7 +995,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1088,7 +1088,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1166,7 +1166,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1241,7 +1241,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1327,7 +1327,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1411,7 +1411,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1495,7 +1495,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1586,7 +1586,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1676,7 +1676,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1760,7 +1760,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1845,7 +1845,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1937,7 +1937,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2013,7 +2013,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2087,7 +2087,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2171,7 +2171,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2255,7 +2255,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2339,7 +2339,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2429,7 +2429,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2519,7 +2519,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2603,7 +2603,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2688,7 +2688,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2782,7 +2782,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2859,7 +2859,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2933,7 +2933,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3018,7 +3018,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3102,7 +3102,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3186,7 +3186,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3276,7 +3276,7 @@ class LegacyCreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.T
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/legacy/LegacyGetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/legacy/LegacyGetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest.kt
@@ -55,7 +55,7 @@ class LegacyGetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest(va
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -63,7 +63,7 @@ class LegacyGetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest(va
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -154,7 +154,7 @@ class LegacyGetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest(va
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -162,7 +162,7 @@ class LegacyGetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest(va
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -253,7 +253,7 @@ class LegacyGetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest(va
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -261,7 +261,7 @@ class LegacyGetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest(va
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -354,7 +354,7 @@ class LegacyGetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest(va
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -362,7 +362,7 @@ class LegacyGetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest(va
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse4>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/legacy/LegacyGetDomesticStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/legacy/LegacyGetDomesticStandingOrderTest.kt
@@ -59,7 +59,7 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -67,7 +67,7 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -165,7 +165,7 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -173,7 +173,7 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -275,7 +275,7 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -283,7 +283,7 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -384,7 +384,7 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -392,7 +392,7 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -487,7 +487,7 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -495,7 +495,7 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -589,7 +589,7 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -597,7 +597,7 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -695,7 +695,7 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -703,7 +703,7 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -801,7 +801,7 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -809,7 +809,7 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -903,7 +903,7 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -911,7 +911,7 @@ class LegacyGetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppR
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteDomesticStandingOrderConsentResponse2>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
@@ -17,6 +17,7 @@ import com.forgerock.uk.openbanking.framework.errors.INVALID_FORMAT_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.errors.NO_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.errors.PAYMENT_SUBMISSION_ALREADY_EXISTS
 import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.api.v3_1_8.CreateInternationalPaymentsConsents
@@ -29,8 +30,8 @@ class CreateInternationalPayment(
     val version: OBVersion,
     val tppResource: CreateTppCallback.TppResource
 ) {
-
     private val createInternationalPaymentsConsents = CreateInternationalPaymentsConsents(version, tppResource)
+    private val paymentLinks = getPaymentsApiLinks(version)
 
     fun createInternationalPayment_rateType_AGREED_Test() {
         // Given
@@ -46,7 +47,7 @@ class CreateInternationalPayment(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -73,7 +74,7 @@ class CreateInternationalPayment(
 
         // When
         val result = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+            paymentLinks.CreateInternationalPayment,
             paymentSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -105,7 +106,7 @@ class CreateInternationalPayment(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -132,7 +133,7 @@ class CreateInternationalPayment(
 
         // When
         val result = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+            paymentLinks.CreateInternationalPayment,
             paymentSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -163,7 +164,7 @@ class CreateInternationalPayment(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -190,7 +191,7 @@ class CreateInternationalPayment(
 
         // When
         val result = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+            paymentLinks.CreateInternationalPayment,
             paymentSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -219,7 +220,7 @@ class CreateInternationalPayment(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -246,7 +247,7 @@ class CreateInternationalPayment(
 
         // When
         val result = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+            paymentLinks.CreateInternationalPayment,
             paymentSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -274,7 +275,7 @@ class CreateInternationalPayment(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -298,7 +299,7 @@ class CreateInternationalPayment(
             tppResource.tpp.signingKid
         )
         val result = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+            paymentLinks.CreateInternationalPayment,
             paymentSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -309,7 +310,7 @@ class CreateInternationalPayment(
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-                createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+                paymentLinks.CreateInternationalPayment,
                 paymentSubmissionRequest,
                 accessTokenAuthorizationCode,
                 signedPayload,
@@ -336,7 +337,7 @@ class CreateInternationalPayment(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -357,7 +358,7 @@ class CreateInternationalPayment(
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-                createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+                paymentLinks.CreateInternationalPayment,
                 paymentSubmissionRequest,
                 accessTokenAuthorizationCode,
                 INVALID_FORMAT_DETACHED_JWS,
@@ -384,7 +385,7 @@ class CreateInternationalPayment(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -406,7 +407,7 @@ class CreateInternationalPayment(
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().submitPaymentNoDetachedJws<OBWriteInternationalResponse5>(
-                createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+                paymentLinks.CreateInternationalPayment,
                 paymentSubmissionRequest,
                 accessTokenAuthorizationCode
             )
@@ -430,7 +431,7 @@ class CreateInternationalPayment(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -459,7 +460,7 @@ class CreateInternationalPayment(
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-                createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+                paymentLinks.CreateInternationalPayment,
                 paymentSubmissionRequest,
                 accessTokenAuthorizationCode,
                 signedPayload,
@@ -486,7 +487,7 @@ class CreateInternationalPayment(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -514,7 +515,7 @@ class CreateInternationalPayment(
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-                createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+                paymentLinks.CreateInternationalPayment,
                 paymentSubmissionRequest,
                 accessTokenAuthorizationCode,
                 signedPayload,
@@ -541,7 +542,7 @@ class CreateInternationalPayment(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -575,7 +576,7 @@ class CreateInternationalPayment(
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-                createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+                paymentLinks.CreateInternationalPayment,
                 paymentSubmissionRequest,
                 accessTokenAuthorizationCode,
                 signedPayload,
@@ -602,7 +603,7 @@ class CreateInternationalPayment(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -636,7 +637,7 @@ class CreateInternationalPayment(
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-                createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+                paymentLinks.CreateInternationalPayment,
                 paymentSubmissionRequest,
                 accessTokenAuthorizationCode,
                 signedPayload,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
@@ -6,20 +6,20 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.conditions.Status
+import com.forgerock.securebanking.framework.data.AccessToken
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.http.fuel.defaultMapper
-import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.framework.constants.INVALID_CONSENT_ID
-import com.forgerock.uk.openbanking.framework.constants.INVALID_FORMAT_DETACHED_JWS
-import com.forgerock.uk.openbanking.framework.constants.INVALID_SIGNING_KID
 import com.forgerock.uk.openbanking.framework.errors.INVALID_FORMAT_DETACHED_JWS_ERROR
 import com.forgerock.uk.openbanking.framework.errors.NO_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.errors.PAYMENT_SUBMISSION_ALREADY_EXISTS
 import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
+import com.forgerock.uk.openbanking.support.payment.BadJwsSignatureProducer
+import com.forgerock.uk.openbanking.support.payment.DefaultJwsSignatureProducer
+import com.forgerock.uk.openbanking.support.payment.InvalidKidJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.api.v3_1_8.CreateInternationalPaymentsConsents
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
@@ -32,55 +32,15 @@ class CreateInternationalPayment(
 ) {
     private val createInternationalPaymentsConsents = CreateInternationalPaymentsConsents(version, tppResource)
     private val paymentLinks = getPaymentsApiLinks(version)
+    private val createPaymentUrl = paymentLinks.CreateInternationalPayment
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun createInternationalPayment_rateType_AGREED_Test() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
         consentRequest.data.initiation.exchangeRateInformation.rateType = OBExchangeRateType2Code.AGREED
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.data.initiation).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
         // When
-        val result = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            paymentLinks.CreateInternationalPayment,
-            paymentSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
+        val result = submitPayment(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -96,50 +56,8 @@ class CreateInternationalPayment(
         consentRequest.data.initiation.exchangeRateInformation.exchangeRate = null
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
 
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.data.initiation).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
         // When
-        val result = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            paymentLinks.CreateInternationalPayment,
-            paymentSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
+        val result = submitPayment(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -154,50 +72,8 @@ class CreateInternationalPayment(
         consentRequest.data.initiation.exchangeRateInformation.exchangeRate = null
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
 
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.data.initiation).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
         // When
-        val result = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            paymentLinks.CreateInternationalPayment,
-            paymentSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
+        val result = submitPayment(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -210,50 +86,8 @@ class CreateInternationalPayment(
         val consentRequest =
             OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5MandatoryFields()
 
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.data.initiation).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
         // When
-        val result = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            paymentLinks.CreateInternationalPayment,
-            paymentSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
+        val result = submitPayment(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -265,58 +99,24 @@ class CreateInternationalPayment(
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
 
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
+        val (consent, authorizationToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+            consentRequest
+        )
 
         assertThat(consent).isNotNull()
         assertThat(consent.data).isNotNull()
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-        val result = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            paymentLinks.CreateInternationalPayment,
-            paymentSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
+        // When
+        val patchedConsent = getPatchedConsent(consent)
+        // Submit first payment
+        submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-                paymentLinks.CreateInternationalPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode,
-                signedPayload,
-                tppResource.tpp,
-                version
-            )
+            // Verify we fail to submit a second payment
+            submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
         }
 
         // Then
@@ -327,44 +127,21 @@ class CreateInternationalPayment(
     fun shouldCreateInternationalPayment_throwsSendInvalidFormatDetachedJws_Test() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
+        val (consent, accessToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+            consentRequest
+        )
 
         assertThat(consent).isNotNull()
         assertThat(consent.data).isNotNull()
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
+        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-                paymentLinks.CreateInternationalPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode,
-                INVALID_FORMAT_DETACHED_JWS,
-                tppResource.tpp,
-                version
-            )
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
+                .configureJwsSignatureProducer(BadJwsSignatureProducer()).sendRequest()
         }
 
         // Then
@@ -375,44 +152,22 @@ class CreateInternationalPayment(
     fun shouldCreateInternationalPayment_throwsNoDetachedJws_Test() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
+        val (consent, accessToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+            consentRequest
+        )
 
         assertThat(consent).isNotNull()
         assertThat(consent.data).isNotNull()
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
+        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPaymentNoDetachedJws<OBWriteInternationalResponse5>(
-                paymentLinks.CreateInternationalPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode
-            )
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
+                .configureJwsSignatureProducer(null).sendRequest()
         }
-
         // Then
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
         assertThat(exception.message.toString()).contains(NO_DETACHED_JWS)
@@ -421,52 +176,21 @@ class CreateInternationalPayment(
     fun shouldCreateInternationalPayment_throwsNotPermittedB64HeaderAddedInTheDetachedJws_Test() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
+        val (consent, accessToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+            consentRequest
+        )
 
         assertThat(consent).isNotNull()
         assertThat(consent.data).isNotNull()
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(paymentSubmissionRequest),
-                tppResource.tpp.signingKey,
-                tppResource.tpp.signingKid,
-                true
-            )
+        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-                paymentLinks.CreateInternationalPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode,
-                signedPayload,
-                tppResource.tpp,
-                version
-            )
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
+                .configureJwsSignatureProducer(DefaultJwsSignatureProducer(tppResource.tpp, false)).sendRequest()
         }
 
         // Then
@@ -477,51 +201,21 @@ class CreateInternationalPayment(
     fun shouldCreateInternationalPayment_throwsSendInvalidKidDetachedJws_Test() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
+        val (consent, accessToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+            consentRequest
+        )
 
         assertThat(consent).isNotNull()
         assertThat(consent.data).isNotNull()
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(paymentSubmissionRequest),
-                tppResource.tpp.signingKey,
-                INVALID_SIGNING_KID
-            )
+        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-                paymentLinks.CreateInternationalPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode,
-                signedPayload,
-                tppResource.tpp,
-                version
-            )
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
+                .configureJwsSignatureProducer(InvalidKidJwsSignatureProducer(tppResource.tpp)).sendRequest()
         }
 
         // Then
@@ -532,59 +226,30 @@ class CreateInternationalPayment(
     fun shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_Test() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
+        val (consent, accessToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+            consentRequest
+        )
 
         assertThat(consent).isNotNull()
         assertThat(consent.data).isNotNull()
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
+        val patchedConsent = getPatchedConsent(consent)
+        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
 
         patchedConsent.data.consentId = INVALID_CONSENT_ID
-        val paymentSubmissionWithInvalidConsentId = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
+        val paymentSubmissionWithInvalidConsentId = createPaymentRequest(patchedConsent)
 
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionWithInvalidConsentId),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
+        val signatureWithInvalidConsentId = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
+            defaultMapper.writeValueAsString(paymentSubmissionWithInvalidConsentId)
         )
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-                paymentLinks.CreateInternationalPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode,
-                signedPayload,
-                tppResource.tpp,
-                version
-            )
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
+                .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidConsentId)).sendRequest()
         }
-
         // Then
         assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
@@ -593,61 +258,76 @@ class CreateInternationalPayment(
     fun shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_Test() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
+        val (consent, accessToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+            consentRequest
+        )
 
         assertThat(consent).isNotNull()
         assertThat(consent.data).isNotNull()
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
+        val patchedConsent = getPatchedConsent(consent)
+        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
 
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternational3().data(
+        val paymentSubmissionInvalidAmount = OBWriteInternational3().data(
             OBWriteInternational3Data()
                 .consentId(patchedConsent.data.consentId)
                 .initiation(PaymentFactory.copyOBWriteInternational3DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
+        paymentSubmissionInvalidAmount.data.initiation.instructedAmount = OBWriteDomestic2DataInitiationInstructedAmount().amount("123123").currency("GBP")
 
-        patchedConsent.data.initiation.instructedAmount.amount = "123123"
-        val paymentSubmissionInvalidAmount = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionInvalidAmount),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
+        val signatureWithInvalidAmount = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
+            defaultMapper.writeValueAsString(paymentSubmissionInvalidAmount)
         )
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-                paymentLinks.CreateInternationalPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode,
-                signedPayload,
-                tppResource.tpp,
-                version
-            )
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
+                .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidAmount)).sendRequest()
         }
 
         // Then
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
         assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+    }
+
+    fun submitPayment(consentRequest: OBWriteInternationalConsent5): OBWriteInternationalResponse5 {
+        val (consent, authorizationToken) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+            consentRequest
+        )
+        return submitPayment(consent, authorizationToken)
+    }
+
+    fun submitPayment(
+        consentResponse: OBWriteInternationalConsentResponse6,
+        authorizationToken: AccessToken
+    ): OBWriteInternationalResponse5 {
+        val patchedConsent = getPatchedConsent(consentResponse)
+        return submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
+    }
+
+    private fun getPatchedConsent(consent: OBWriteInternationalConsentResponse6): OBWriteInternationalConsentResponse6 {
+        return createInternationalPaymentsConsents.getPatchedConsent(consent)
+    }
+
+    private fun submitPaymentForPatchedConsent(
+        patchedConsent: OBWriteInternationalConsentResponse6,
+        authorizationToken: AccessToken
+    ): OBWriteInternationalResponse5 {
+        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
+        return paymentApiClient.submitPayment(
+            createPaymentUrl,
+            authorizationToken,
+            paymentSubmissionRequest
+        )
+    }
+
+    private fun createPaymentRequest(patchedConsent: OBWriteInternationalConsentResponse6): OBWriteInternational3 {
+        return OBWriteInternational3().data(
+            OBWriteInternational3Data()
+                .consentId(patchedConsent.data.consentId)
+                .initiation(patchedConsent.data.initiation)
+        ).risk(patchedConsent.risk)
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
@@ -23,7 +23,13 @@ import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.api.v3_1_8.CreateInternationalPaymentsConsents
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3Data
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalResponse5
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory
 
 class CreateInternationalPayment(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPayment.kt
@@ -9,6 +9,7 @@ import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.http.fuel.defaultMapper
 import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.api.v3_1_8.CreateInternationalPaymentsConsents
@@ -22,6 +23,7 @@ class GetInternationalPayment(
 ) {
 
     private val createInternationalPaymentsConsents = CreateInternationalPaymentsConsents(version, tppResource)
+    private val paymentLinks = getPaymentsApiLinks(version)
 
     fun getInternationalPayments_rateType_AGREED_Test() {
         // Given
@@ -41,7 +43,7 @@ class GetInternationalPayment(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -67,7 +69,7 @@ class GetInternationalPayment(
         )
 
         val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+            paymentLinks.CreateInternationalPayment,
             standingOrderSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -83,7 +85,7 @@ class GetInternationalPayment(
         // When
         val result = PaymentRS().getPayment<OBWriteInternationalResponse5>(
             PaymentFactory.urlWithInternationalPaymentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPayment,
+                paymentLinks.GetInternationalPayment,
                 submissionResponse.data.internationalPaymentId
             ),
             accessTokenClientCredentials,
@@ -118,7 +120,7 @@ class GetInternationalPayment(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -144,7 +146,7 @@ class GetInternationalPayment(
         )
 
         val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+            paymentLinks.CreateInternationalPayment,
             standingOrderSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -160,7 +162,7 @@ class GetInternationalPayment(
         // When
         val result = PaymentRS().getPayment<OBWriteInternationalResponse5>(
             PaymentFactory.urlWithInternationalPaymentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPayment,
+                paymentLinks.GetInternationalPayment,
                 submissionResponse.data.internationalPaymentId
             ),
             accessTokenClientCredentials,
@@ -194,7 +196,7 @@ class GetInternationalPayment(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -220,7 +222,7 @@ class GetInternationalPayment(
         )
 
         val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+            paymentLinks.CreateInternationalPayment,
             standingOrderSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -236,7 +238,7 @@ class GetInternationalPayment(
         // When
         val result = PaymentRS().getPayment<OBWriteInternationalResponse5>(
             PaymentFactory.urlWithInternationalPaymentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPayment,
+                paymentLinks.GetInternationalPayment,
                 submissionResponse.data.internationalPaymentId
             ),
             accessTokenClientCredentials,
@@ -268,7 +270,7 @@ class GetInternationalPayment(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -294,7 +296,7 @@ class GetInternationalPayment(
         )
 
         val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+            paymentLinks.CreateInternationalPayment,
             standingOrderSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -310,7 +312,7 @@ class GetInternationalPayment(
         // When
         val result = PaymentRS().getPayment<OBWriteInternationalResponse5>(
             PaymentFactory.urlWithInternationalPaymentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPayment,
+                paymentLinks.GetInternationalPayment,
                 submissionResponse.data.internationalPaymentId
             ),
             accessTokenClientCredentials,
@@ -343,7 +345,7 @@ class GetInternationalPayment(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -370,7 +372,7 @@ class GetInternationalPayment(
         )
 
         val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+            paymentLinks.CreateInternationalPayment,
             standingOrderSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -386,7 +388,7 @@ class GetInternationalPayment(
         // When
         val result = PaymentRS().getPayment<OBWriteInternationalResponse5>(
             PaymentFactory.urlWithInternationalPaymentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPayment,
+                paymentLinks.GetInternationalPayment,
                 submissionResponse.data.internationalPaymentId
             ),
             accessTokenClientCredentials,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPayment.kt
@@ -1,18 +1,14 @@
 package com.forgerock.uk.openbanking.tests.functional.payment.international.payments.api.v3_1_8
 
 import assertk.assertThat
-import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
-import com.forgerock.securebanking.framework.http.fuel.defaultMapper
-import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
-import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.api.v3_1_8.CreateInternationalPaymentsConsents
+import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import org.assertj.core.api.Assertions
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory
@@ -21,76 +17,18 @@ class GetInternationalPayment(
     val version: OBVersion,
     val tppResource: CreateTppCallback.TppResource
 ) {
-
-    private val createInternationalPaymentsConsents = CreateInternationalPaymentsConsents(version, tppResource)
+    private val createInternationalPayment = CreateInternationalPayment(version, tppResource)
     private val paymentLinks = getPaymentsApiLinks(version)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun getInternationalPayments_rateType_AGREED_Test() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
         consentRequest.data.initiation.exchangeRateInformation.rateType = OBExchangeRateType2Code.AGREED
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        assertThat(consent.data.initiation.exchangeRateInformation.exchangeRate).isNotNull()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            paymentLinks.CreateInternationalPayment,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.internationalPaymentId).isNotEmpty()
+        val paymentResponse = createInternationalPayment.submitPayment(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWriteInternationalResponse5>(
-            PaymentFactory.urlWithInternationalPaymentId(
-                paymentLinks.GetInternationalPayment,
-                submissionResponse.data.internationalPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val result = getInternationalPayment(paymentResponse)
 
         // Then
         assertThat(result).isNotNull()
@@ -107,67 +45,10 @@ class GetInternationalPayment(
         consentRequest.data.initiation.exchangeRateInformation.exchangeRate = null
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
 
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            paymentLinks.CreateInternationalPayment,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.internationalPaymentId).isNotEmpty()
+        val paymentResponse = createInternationalPayment.submitPayment(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWriteInternationalResponse5>(
-            PaymentFactory.urlWithInternationalPaymentId(
-                paymentLinks.GetInternationalPayment,
-                submissionResponse.data.internationalPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val result = getInternationalPayment(paymentResponse)
 
         // Then
         assertThat(result).isNotNull()
@@ -183,67 +64,10 @@ class GetInternationalPayment(
         consentRequest.data.initiation.exchangeRateInformation.exchangeRate = null
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
 
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            paymentLinks.CreateInternationalPayment,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.internationalPaymentId).isNotEmpty()
+        val paymentResponse = createInternationalPayment.submitPayment(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWriteInternationalResponse5>(
-            PaymentFactory.urlWithInternationalPaymentId(
-                paymentLinks.GetInternationalPayment,
-                submissionResponse.data.internationalPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val result = getInternationalPayment(paymentResponse)
 
         // Then
         assertThat(result).isNotNull()
@@ -257,67 +81,10 @@ class GetInternationalPayment(
         val consentRequest =
             OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5MandatoryFields()
 
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            paymentLinks.CreateInternationalPayment,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.internationalPaymentId).isNotEmpty()
+        val paymentResponse = createInternationalPayment.submitPayment(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWriteInternationalResponse5>(
-            PaymentFactory.urlWithInternationalPaymentId(
-                paymentLinks.GetInternationalPayment,
-                submissionResponse.data.internationalPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val result = getInternationalPayment(paymentResponse)
 
         // Then
         assertThat(result).isNotNull()
@@ -331,69 +98,10 @@ class GetInternationalPayment(
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
         consentRequest.data.readRefundAccount = OBReadRefundAccountEnum.YES
 
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        assertThat(consent.data.readRefundAccount).isEqualTo(OBReadRefundAccountEnum.YES)
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        assertThat(patchedConsent.data.readRefundAccount).isEqualTo(OBReadRefundAccountEnum.YES)
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            paymentLinks.CreateInternationalPayment,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.internationalPaymentId).isNotEmpty()
+        val paymentResponse = createInternationalPayment.submitPayment(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWriteInternationalResponse5>(
-            PaymentFactory.urlWithInternationalPaymentId(
-                paymentLinks.GetInternationalPayment,
-                submissionResponse.data.internationalPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val result = getInternationalPayment(paymentResponse)
 
         // Then
         assertThat(result).isNotNull()
@@ -402,5 +110,16 @@ class GetInternationalPayment(
         //TODO: Waiting for the fix from the issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/241
 //        assertThat(result.data.refund.account.identification).isEqualTo(consent.data.initiation.debtorAccount.identification)
         Assertions.assertThat(result.data.status.toString()).`is`(Status.paymentCondition)
+    }
+
+    private fun getInternationalPayment(paymentResponse: OBWriteInternationalResponse5): OBWriteInternationalResponse5 {
+        val getDomesticPaymentUrl = PaymentFactory.urlWithInternationalPaymentId(
+            paymentLinks.GetInternationalPayment,
+            paymentResponse.data.internationalPaymentId
+        )
+        return paymentApiClient.sendGetRequest(
+            getDomesticPaymentUrl,
+            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
+        )
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPayment.kt
@@ -37,7 +37,7 @@ class GetInternationalPayment(
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
@@ -114,7 +114,7 @@ class GetInternationalPayment(
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
@@ -190,7 +190,7 @@ class GetInternationalPayment(
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
@@ -264,7 +264,7 @@ class GetInternationalPayment(
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
@@ -339,7 +339,7 @@ class GetInternationalPayment(
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPayment.kt
@@ -10,7 +10,9 @@ import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code
+import uk.org.openbanking.datamodel.payment.OBReadRefundAccountEnum
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalResponse5
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory
 
 class GetInternationalPayment(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPaymentInternationalPaymentIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPaymentInternationalPaymentIdPaymentDetails.kt
@@ -9,6 +9,7 @@ import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.http.fuel.defaultMapper
 import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.api.v3_1_8.CreateInternationalPaymentsConsents
@@ -22,6 +23,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
 ) {
 
     private val createInternationalPaymentsConsents = CreateInternationalPaymentsConsents(version, tppResource)
+    private val paymentLinks = getPaymentsApiLinks(version)
 
     fun getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_AGREED_Test() {
         // Given
@@ -42,7 +44,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -68,7 +70,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
         )
 
         val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+            paymentLinks.CreateInternationalPayment,
             standingOrderSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -84,7 +86,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
         // When
         val result = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
             PaymentFactory.urlWithInternationalPaymentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentInternationalPaymentIdPaymentDetails,
+                paymentLinks.GetInternationalPaymentInternationalPaymentIdPaymentDetails,
                 submissionResponse.data.internationalPaymentId
             ),
             accessTokenClientCredentials,
@@ -117,7 +119,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -143,7 +145,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
         )
 
         val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+            paymentLinks.CreateInternationalPayment,
             standingOrderSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -159,7 +161,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
         // When
         val result = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
             PaymentFactory.urlWithInternationalPaymentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentInternationalPaymentIdPaymentDetails,
+                paymentLinks.GetInternationalPaymentInternationalPaymentIdPaymentDetails,
                 submissionResponse.data.internationalPaymentId
             ),
             accessTokenClientCredentials,
@@ -192,7 +194,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -218,7 +220,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
         )
 
         val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+            paymentLinks.CreateInternationalPayment,
             standingOrderSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -234,7 +236,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
         // When
         val result = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
             PaymentFactory.urlWithInternationalPaymentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentInternationalPaymentIdPaymentDetails,
+                paymentLinks.GetInternationalPaymentInternationalPaymentIdPaymentDetails,
                 submissionResponse.data.internationalPaymentId
             ),
             accessTokenClientCredentials,
@@ -265,7 +267,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -291,7 +293,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
         )
 
         val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            createInternationalPaymentsConsents.paymentLinks.CreateInternationalPayment,
+            paymentLinks.CreateInternationalPayment,
             standingOrderSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -307,7 +309,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
         // When
         val result = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
             PaymentFactory.urlWithInternationalPaymentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentInternationalPaymentIdPaymentDetails,
+                paymentLinks.GetInternationalPaymentInternationalPaymentIdPaymentDetails,
                 submissionResponse.data.internationalPaymentId
             ),
             accessTokenClientCredentials,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPaymentInternationalPaymentIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPaymentInternationalPaymentIdPaymentDetails.kt
@@ -1,19 +1,12 @@
 package com.forgerock.uk.openbanking.tests.functional.payment.international.payments.api.v3_1_8
 
 import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
-import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
-import com.forgerock.securebanking.framework.http.fuel.defaultMapper
-import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
-import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.api.v3_1_8.CreateInternationalPaymentsConsents
-import org.assertj.core.api.Assertions
+import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory
 
@@ -21,77 +14,18 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
     val version: OBVersion,
     val tppResource: CreateTppCallback.TppResource
 ) {
-
-    private val createInternationalPaymentsConsents = CreateInternationalPaymentsConsents(version, tppResource)
+    private val createInternationalPayment = CreateInternationalPayment(version, tppResource)
     private val paymentLinks = getPaymentsApiLinks(version)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_AGREED_Test() {
         // Given
         val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
         consentRequest.data.initiation.exchangeRateInformation.rateType = OBExchangeRateType2Code.AGREED
-
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        assertThat(consent.data.initiation.exchangeRateInformation.exchangeRate).isNotNull()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            paymentLinks.CreateInternationalPayment,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.internationalPaymentId).isNotEmpty()
+        val paymentResponse = createInternationalPayment.submitPayment(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
-            PaymentFactory.urlWithInternationalPaymentId(
-                paymentLinks.GetInternationalPaymentInternationalPaymentIdPaymentDetails,
-                submissionResponse.data.internationalPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val result = getPaymentDetails(paymentResponse)
 
         // Then
         assertThat(result).isNotNull()
@@ -106,67 +40,11 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
         consentRequest.data.initiation.exchangeRateInformation.exchangeRate = null
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
 
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            paymentLinks.CreateInternationalPayment,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.internationalPaymentId).isNotEmpty()
+        val paymentResponse = createInternationalPayment.submitPayment(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
-            PaymentFactory.urlWithInternationalPaymentId(
-                paymentLinks.GetInternationalPaymentInternationalPaymentIdPaymentDetails,
-                submissionResponse.data.internationalPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val result = getPaymentDetails(paymentResponse)
+
 
         // Then
         assertThat(result).isNotNull()
@@ -181,67 +59,11 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
         consentRequest.data.initiation.exchangeRateInformation.exchangeRate = null
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
 
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            paymentLinks.CreateInternationalPayment,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.internationalPaymentId).isNotEmpty()
+        val paymentResponse = createInternationalPayment.submitPayment(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
-            PaymentFactory.urlWithInternationalPaymentId(
-                paymentLinks.GetInternationalPaymentInternationalPaymentIdPaymentDetails,
-                submissionResponse.data.internationalPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val result = getPaymentDetails(paymentResponse)
+
 
         // Then
         assertThat(result).isNotNull()
@@ -253,72 +75,26 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
         // Given
         val consentRequest =
             OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5MandatoryFields()
-
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteInternational3().data(
-            OBWriteInternational3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalResponse5>(
-            paymentLinks.CreateInternationalPayment,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.internationalPaymentId).isNotEmpty()
+        val paymentResponse = createInternationalPayment.submitPayment(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
-            PaymentFactory.urlWithInternationalPaymentId(
-                paymentLinks.GetInternationalPaymentInternationalPaymentIdPaymentDetails,
-                submissionResponse.data.internationalPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val result = getPaymentDetails(paymentResponse)
+
 
         // Then
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.paymentStatus).isNotNull()
+    }
+
+    fun getPaymentDetails(paymentResponse: OBWriteInternationalResponse5): OBWritePaymentDetailsResponse1 {
+        val getInternationalPaymentDetails = PaymentFactory.urlWithInternationalPaymentId(
+            paymentLinks.GetInternationalPaymentInternationalPaymentIdPaymentDetails,
+            paymentResponse.data.internationalPaymentId
+        )
+        return paymentApiClient.sendGetRequest(
+            getInternationalPaymentDetails,
+            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
+        )
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPaymentInternationalPaymentIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPaymentInternationalPaymentIdPaymentDetails.kt
@@ -38,7 +38,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
@@ -113,7 +113,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
@@ -188,7 +188,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
@@ -261,7 +261,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPaymentInternationalPaymentIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/GetInternationalPaymentInternationalPaymentIdPaymentDetails.kt
@@ -7,7 +7,9 @@ import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalResponse5
+import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory
 
 class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
@@ -87,7 +89,7 @@ class GetInternationalPaymentInternationalPaymentIdPaymentDetails(
         assertThat(result.data.paymentStatus).isNotNull()
     }
 
-    fun getPaymentDetails(paymentResponse: OBWriteInternationalResponse5): OBWritePaymentDetailsResponse1 {
+    private fun getPaymentDetails(paymentResponse: OBWriteInternationalResponse5): OBWritePaymentDetailsResponse1 {
         val getInternationalPaymentDetails = PaymentFactory.urlWithInternationalPaymentId(
             paymentLinks.GetInternationalPaymentInternationalPaymentIdPaymentDetails,
             paymentResponse.data.internationalPaymentId

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/CreateInternationalPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/CreateInternationalPaymentsConsents.kt
@@ -119,7 +119,7 @@ class CreateInternationalPaymentsConsents(val version: OBVersion, val tppResourc
 
     private fun buildCreateConsentRequest(
         consent: OBWriteInternationalConsent5
-    ) = paymentApiClient.createDefaultPostRequest(
+    ) = paymentApiClient.newPostRequestBuilder(
         paymentLinks.CreateInternationalPaymentConsent,
         tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken),
         consent

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/CreateInternationalPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/CreateInternationalPaymentsConsents.kt
@@ -125,7 +125,7 @@ class CreateInternationalPaymentsConsents(val version: OBVersion, val tppResourc
         consent
     )
 
-    fun createInternationalPaymentConsentAndGetAccessToken(consentRequest: OBWriteInternationalConsent5): Pair<OBWriteInternationalConsentResponse6, AccessToken> {
+    fun createInternationalPaymentConsentAndAuthorize(consentRequest: OBWriteInternationalConsent5): Pair<OBWriteInternationalConsentResponse6, AccessToken> {
         val consent = createInternationalPaymentConsent(consentRequest)
         val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
@@ -134,5 +134,19 @@ class CreateInternationalPaymentsConsents(val version: OBVersion, val tppResourc
             tppResource.tpp
         )
         return consent to accessTokenAuthorizationCode
+    }
+
+    fun getPatchedConsent(consent: OBWriteInternationalConsentResponse6): OBWriteInternationalConsentResponse6 {
+        val patchedConsent = paymentApiClient.getConsent<OBWriteInternationalConsentResponse6>(
+            paymentLinks.GetInternationalPaymentConsent,
+            consent.data.consentId,
+            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
+        )
+        assertThat(patchedConsent).isNotNull()
+        assertThat(patchedConsent.data).isNotNull()
+        assertThat(patchedConsent.risk).isNotNull()
+        assertThat(patchedConsent.data.consentId).isNotEmpty()
+        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
+        return patchedConsent
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/CreateInternationalPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/CreateInternationalPaymentsConsents.kt
@@ -9,11 +9,7 @@ import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.configuration.psu
 import com.forgerock.securebanking.framework.data.AccessToken
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
-import com.forgerock.securebanking.framework.http.fuel.defaultMapper
-import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
-import com.forgerock.uk.openbanking.framework.constants.INVALID_FORMAT_DETACHED_JWS
-import com.forgerock.uk.openbanking.framework.constants.INVALID_SIGNING_KID
 import com.forgerock.uk.openbanking.framework.errors.INVALID_FORMAT_DETACHED_JWS_ERROR
 import com.forgerock.uk.openbanking.framework.errors.NO_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
@@ -22,18 +18,16 @@ import com.forgerock.uk.openbanking.support.payment.BadJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.DefaultJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.InvalidKidJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.PaymentAS
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory
 
 class CreateInternationalPaymentsConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
-    val paymentLinks = getPaymentsApiLinks(version)
+    private val paymentLinks = getPaymentsApiLinks(version)
     private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun createInternationalPaymentsConsents() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsentFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsentFundsConfirmation.kt
@@ -10,6 +10,7 @@ import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.framework.errors.INVALID_CONSENT_STATUS
 import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentAS
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
@@ -26,7 +27,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
 ) {
 
     private val createInternationalPaymentsConsents = CreateInternationalPaymentsConsents(version, tppResource)
-
+    private val paymentLinks = getPaymentsApiLinks(version)
     fun shouldGetInternationalPaymentConsentsFundsConfirmation_true_rateType_AGREED_Test() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent5()
@@ -46,7 +47,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         // When
         val result = PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
+                paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
                 consent.data.consentId
             ),
             accessTokenAuthorizationCode
@@ -80,7 +81,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         // When
         val result = PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
+                paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
                 consent.data.consentId
             ),
             accessTokenAuthorizationCode
@@ -114,7 +115,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         // When
         val result = PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
+                paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
                 consent.data.consentId
             ),
             accessTokenAuthorizationCode
@@ -147,7 +148,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         // When
         val result = PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
+                paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
                 consent.data.consentId
             ),
             accessTokenAuthorizationCode
@@ -177,7 +178,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
             )
 
         val consent = PaymentRS().consent<OBWriteInternationalConsentResponse6>(
-            createInternationalPaymentsConsents.paymentLinks.CreateInternationalPaymentConsent,
+            paymentLinks.CreateInternationalPaymentConsent,
             consentRequest,
             tppResource.tpp,
             version,
@@ -201,7 +202,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         // When
         val result = PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
+                paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
                 consent.data.consentId
             ),
             accessTokenAuthorizationCode
@@ -231,7 +232,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
             )
 
         val consent = PaymentRS().consent<OBWriteInternationalConsentResponse6>(
-            createInternationalPaymentsConsents.paymentLinks.CreateInternationalPaymentConsent,
+            paymentLinks.CreateInternationalPaymentConsent,
             consentRequest,
             tppResource.tpp,
             version,
@@ -255,7 +256,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         // When
         val result = PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
+                paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
                 consent.data.consentId
             ),
             accessTokenAuthorizationCode
@@ -281,7 +282,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
             )
 
         val consent = PaymentRS().consent<OBWriteInternationalConsentResponse6>(
-            createInternationalPaymentsConsents.paymentLinks.CreateInternationalPaymentConsent,
+            paymentLinks.CreateInternationalPaymentConsent,
             consentRequest,
             tppResource.tpp,
             version,
@@ -301,7 +302,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
                 PaymentFactory.urlWithConsentId(
-                    createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
+                    paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
                     consent.data.consentId
                 ),
                 accessTokenClientCredentials
@@ -325,7 +326,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
             )
 
         val consent = PaymentRS().consent<OBWriteInternationalConsentResponse6>(
-            createInternationalPaymentsConsents.paymentLinks.CreateInternationalPaymentConsent,
+            paymentLinks.CreateInternationalPaymentConsent,
             consentRequest,
             tppResource.tpp,
             version,
@@ -350,7 +351,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
                 PaymentFactory.urlWithConsentId(
-                    createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
+                    paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
                     consent.data.consentId
                 ),
                 accessTokenAuthorizationCode

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsentFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsentFundsConfirmation.kt
@@ -25,9 +25,9 @@ class GetInternationalPaymentsConsentFundsConfirmation(
     val version: OBVersion,
     val tppResource: CreateTppCallback.TppResource
 ) {
-
     private val createInternationalPaymentsConsents = CreateInternationalPaymentsConsents(version, tppResource)
     private val paymentLinks = getPaymentsApiLinks(version)
+
     fun shouldGetInternationalPaymentConsentsFundsConfirmation_true_rateType_AGREED_Test() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent5()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsentFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsentFundsConfirmation.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.*
 import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.configuration.psu
+import com.forgerock.securebanking.framework.data.AccessToken
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.http.fuel.defaultMapper
 import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
@@ -18,6 +19,7 @@ import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
 import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code
 import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5
 
@@ -27,6 +29,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
 ) {
     private val createInternationalPaymentsConsents = CreateInternationalPaymentsConsents(version, tppResource)
     private val paymentLinks = getPaymentsApiLinks(version)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun shouldGetInternationalPaymentConsentsFundsConfirmation_true_rateType_AGREED_Test() {
         // Given
@@ -34,24 +37,8 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         consentRequest.data.initiation.exchangeRateInformation.rateType = OBExchangeRateType2Code.AGREED
         consentRequest.data.initiation.instructedAmount.amount("3")
 
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-        assertThat(consent.data.initiation.exchangeRateInformation.exchangeRate).isNotNull()
-
         // When
-        val result = PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
-                consent.data.consentId
-            ),
-            accessTokenAuthorizationCode
-        )
+        val result = createConsentAndGetFundsConfirmation(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -69,23 +56,8 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
         consentRequest.data.initiation.instructedAmount.amount("3")
 
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-
         // When
-        val result = PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
-                consent.data.consentId
-            ),
-            accessTokenAuthorizationCode
-        )
+        val result = createConsentAndGetFundsConfirmation(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -103,23 +75,8 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
         consentRequest.data.initiation.instructedAmount.amount("3")
 
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-
         // When
-        val result = PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
-                consent.data.consentId
-            ),
-            accessTokenAuthorizationCode
-        )
+        val result = createConsentAndGetFundsConfirmation(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -135,24 +92,8 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         consentRequest.data.initiation.exchangeRateInformation.rateType = OBExchangeRateType2Code.AGREED
         consentRequest.data.initiation.instructedAmount.amount("1000000")
 
-        val (consent, accessTokenAuthorizationCode) =
-            createInternationalPaymentsConsents.createInternationalPaymentConsentAndGetAccessToken(consentRequest)
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-        assertThat(consent.data.initiation.exchangeRateInformation.exchangeRate).isNotNull()
-
         // When
-        val result = PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
-                consent.data.consentId
-            ),
-            accessTokenAuthorizationCode
-        )
+        val result = createConsentAndGetFundsConfirmation(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -170,43 +111,8 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
         consentRequest.data.initiation.instructedAmount.amount("1000000")
 
-        val signedPayloadConsent =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(consentRequest),
-                tppResource.tpp.signingKey,
-                tppResource.tpp.signingKid
-            )
-
-        val consent = PaymentRS().consent<OBWriteInternationalConsentResponse6>(
-            paymentLinks.CreateInternationalPaymentConsent,
-            consentRequest,
-            tppResource.tpp,
-            version,
-            signedPayloadConsent
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-
-        // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
-            consent.data.consentId,
-            tppResource.tpp.registrationResponse,
-            psu,
-            tppResource.tpp
-        )
-
         // When
-        val result = PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
-                consent.data.consentId
-            ),
-            accessTokenAuthorizationCode
-        )
+        val result = createConsentAndGetFundsConfirmation(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -224,43 +130,8 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
         consentRequest.data.initiation.instructedAmount.amount("1000000")
 
-        val signedPayloadConsent =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(consentRequest),
-                tppResource.tpp.signingKey,
-                tppResource.tpp.signingKid
-            )
-
-        val consent = PaymentRS().consent<OBWriteInternationalConsentResponse6>(
-            paymentLinks.CreateInternationalPaymentConsent,
-            consentRequest,
-            tppResource.tpp,
-            version,
-            signedPayloadConsent
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-
-        // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
-            consent.data.consentId,
-            tppResource.tpp.registrationResponse,
-            psu,
-            tppResource.tpp
-        )
-
         // When
-        val result = PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
-                consent.data.consentId
-            ),
-            accessTokenAuthorizationCode
-        )
+        val result = createConsentAndGetFundsConfirmation(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -273,40 +144,14 @@ class GetInternationalPaymentsConsentFundsConfirmation(
     fun shouldGetInternationalPaymentConsentsFundsConfirmation_throwsWrongGrantType_Test() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent5()
+        val (consent, _) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(consentRequest)
 
-        val signedPayloadConsent =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(consentRequest),
-                tppResource.tpp.signingKey,
-                tppResource.tpp.signingKid
-            )
-
-        val consent = PaymentRS().consent<OBWriteInternationalConsentResponse6>(
-            paymentLinks.CreateInternationalPaymentConsent,
-            consentRequest,
-            tppResource.tpp,
-            version,
-            signedPayloadConsent
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-
-        // accessToken to get the payment use the grant type client_credentials
+        // client_credentials access token must not be allowed to get the funds confirmation
         val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().getFundsConfirmation<OBWriteFundsConfirmationResponse1>(
-                PaymentFactory.urlWithConsentId(
-                    paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
-                    consent.data.consentId
-                ),
-                accessTokenClientCredentials
-            )
+            getFundsConfirmation(consent, accessTokenClientCredentials)
         }
 
         // Then
@@ -314,6 +159,8 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
     }
 
+    // TODO - Review logic and convert to use paymentApiClient
+    // The logic has not been migrated as it looks invalid and the tests are disabled so we cannot verify.
     fun shouldGetInternationalPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_Test() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent5()
@@ -361,5 +208,24 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         // Then
         assertThat(exception.message.toString()).contains(INVALID_CONSENT_STATUS)
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+    }
+
+    private fun createConsentAndGetFundsConfirmation(consentRequest: OBWriteInternationalConsent5): OBWriteFundsConfirmationResponse1 {
+        val (consent, accessTokenAuthorizationCode) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
+            consentRequest
+        )
+        return getFundsConfirmation(consent, accessTokenAuthorizationCode)
+    }
+
+    private fun getFundsConfirmation(
+        consent: OBWriteInternationalConsentResponse6,
+        accessTokenAuthorizationCode: AccessToken
+    ): OBWriteFundsConfirmationResponse1 {
+        return paymentApiClient.sendGetRequest(
+            PaymentFactory.urlWithConsentId(
+                paymentLinks.GetInternationalPaymentConsentsConsentIdFundsConfirmation,
+                consent.data.consentId
+            ), accessTokenAuthorizationCode
+        )
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsentFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsentFundsConfirmation.kt
@@ -191,7 +191,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         assertThat(consent.risk).isNotNull()
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -245,7 +245,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         assertThat(consent.risk).isNotNull()
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -295,7 +295,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         assertThat(consent.risk).isNotNull()
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
@@ -339,7 +339,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         assertThat(consent.risk).isNotNull()
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsentFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsentFundsConfirmation.kt
@@ -1,7 +1,12 @@
 package com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.api.v3_1_8
 
 import assertk.assertThat
-import assertk.assertions.*
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotEmpty
+import assertk.assertions.isNotNull
+import assertk.assertions.isTrue
 import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.configuration.psu
 import com.forgerock.securebanking.framework.data.AccessToken

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsents.kt
@@ -8,11 +8,8 @@ import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
-import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
 import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory
 
 class GetInternationalPaymentsConsents(
@@ -37,14 +34,7 @@ class GetInternationalPaymentsConsents(
         assertThat(consent.data.initiation.exchangeRateInformation.exchangeRate).isNotNull()
 
         // When
-        val result = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
+        val result = createInternationalPaymentsConsents.getPatchedConsent(consent)
 
         // Then
         assertThat(result).isNotNull()
@@ -70,14 +60,7 @@ class GetInternationalPaymentsConsents(
         assertThat(consent.risk).isNotNull()
 
         // When
-        val result = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
+        val result = createInternationalPaymentsConsents.getPatchedConsent(consent)
 
         // Then
         assertThat(result).isNotNull()
@@ -103,14 +86,7 @@ class GetInternationalPaymentsConsents(
         assertThat(consent.risk).isNotNull()
 
         // When
-        val result = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
+        val result = createInternationalPaymentsConsents.getPatchedConsent(consent)
 
         // Then
         assertThat(result).isNotNull()
@@ -119,5 +95,4 @@ class GetInternationalPaymentsConsents(
         assertThat(result.data).isEqualTo(consent.data)
         assertThat(result.risk).isEqualTo(consent.risk)
     }
-
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsents.kt
@@ -7,6 +7,7 @@ import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
@@ -18,8 +19,8 @@ class GetInternationalPaymentsConsents(
     val version: OBVersion,
     val tppResource: CreateTppCallback.TppResource
 ) {
-
     private val createInternationalPaymentsConsents = CreateInternationalPaymentsConsents(version, tppResource)
+    private val paymentLinks = getPaymentsApiLinks(version)
 
     fun shouldGetInternationalPaymentsConsents_rateType_AGREED_Test() {
         // Given
@@ -38,7 +39,7 @@ class GetInternationalPaymentsConsents(
         // When
         val result = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -71,7 +72,7 @@ class GetInternationalPaymentsConsents(
         // When
         val result = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -104,7 +105,7 @@ class GetInternationalPaymentsConsents(
         // When
         val result = PaymentRS().getConsent<OBWriteInternationalConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalPaymentsConsents.paymentLinks.GetInternationalPaymentConsent,
+                paymentLinks.GetInternationalPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/legacy/LegacyGetInternationalPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/legacy/LegacyGetInternationalPaymentsConsentFundsConfirmationTest.kt
@@ -63,7 +63,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(consent.data.initiation.exchangeRateInformation.exchangeRate).isNotNull()
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -123,7 +123,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -183,7 +183,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -242,7 +242,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(consent.data.initiation.exchangeRateInformation.exchangeRate).isNotNull()
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -302,7 +302,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -362,7 +362,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -419,7 +419,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         // When
         val exception = assertThrows(AssertionError::class.java) {
@@ -469,7 +469,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -527,7 +527,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(consent.data.initiation.exchangeRateInformation.exchangeRate).isNotNull()
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -587,7 +587,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -647,7 +647,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -706,7 +706,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(consent.data.initiation.exchangeRateInformation.exchangeRate).isNotNull()
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -766,7 +766,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -826,7 +826,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -883,7 +883,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         // When
         val exception = assertThrows(AssertionError::class.java) {
@@ -933,7 +933,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -992,7 +992,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(consent.data.initiation.exchangeRateInformation.exchangeRate).isNotNull()
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1052,7 +1052,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1112,7 +1112,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1171,7 +1171,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(consent.data.initiation.exchangeRateInformation.exchangeRate).isNotNull()
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1231,7 +1231,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1291,7 +1291,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1348,7 +1348,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         // When
         val exception = assertThrows(AssertionError::class.java) {
@@ -1398,7 +1398,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1457,7 +1457,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(consent.data.initiation.exchangeRateInformation.exchangeRate).isNotNull()
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1518,7 +1518,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1579,7 +1579,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1639,7 +1639,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(consent.data.initiation.exchangeRateInformation.exchangeRate).isNotNull()
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1700,7 +1700,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1761,7 +1761,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1819,7 +1819,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         // When
         val exception = assertThrows(AssertionError::class.java) {
@@ -1870,7 +1870,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/legacy/LegacyCreateInternationalPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/legacy/LegacyCreateInternationalPaymentTest.kt
@@ -67,7 +67,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -153,7 +153,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -238,7 +238,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -320,7 +320,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -402,7 +402,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -491,7 +491,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -569,7 +569,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -644,7 +644,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -729,7 +729,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -813,7 +813,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -903,7 +903,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -994,7 +994,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1081,7 +1081,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1167,7 +1167,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1250,7 +1250,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1333,7 +1333,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1425,7 +1425,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1502,7 +1502,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1576,7 +1576,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1661,7 +1661,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1744,7 +1744,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1827,7 +1827,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1917,7 +1917,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2008,7 +2008,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2095,7 +2095,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2181,7 +2181,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2264,7 +2264,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2347,7 +2347,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2439,7 +2439,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2516,7 +2516,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2590,7 +2590,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2675,7 +2675,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2758,7 +2758,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2841,7 +2841,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2931,7 +2931,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3022,7 +3022,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3110,7 +3110,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3197,7 +3197,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3281,7 +3281,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3366,7 +3366,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3458,7 +3458,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3534,7 +3534,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3608,7 +3608,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3692,7 +3692,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3776,7 +3776,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3860,7 +3860,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3950,7 +3950,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4041,7 +4041,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4129,7 +4129,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4216,7 +4216,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4300,7 +4300,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4385,7 +4385,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4479,7 +4479,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4556,7 +4556,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4630,7 +4630,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4715,7 +4715,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4799,7 +4799,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4883,7 +4883,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4973,7 +4973,7 @@ class LegacyCreateInternationalPaymentTest(val tppResource: CreateTppCallback.Tp
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/legacy/LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/legacy/LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest.kt
@@ -57,7 +57,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -65,7 +65,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -159,7 +159,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -167,7 +167,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -261,7 +261,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -269,7 +269,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -360,7 +360,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -368,7 +368,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -461,7 +461,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -469,7 +469,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -565,7 +565,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -573,7 +573,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -669,7 +669,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -677,7 +677,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -770,7 +770,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -778,7 +778,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -873,7 +873,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -881,7 +881,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -977,7 +977,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -985,7 +985,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1081,7 +1081,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1089,7 +1089,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1182,7 +1182,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1190,7 +1190,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1285,7 +1285,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1293,7 +1293,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -1389,7 +1389,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1397,7 +1397,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -1493,7 +1493,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1501,7 +1501,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -1594,7 +1594,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1602,7 +1602,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -1697,7 +1697,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1705,7 +1705,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -1801,7 +1801,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1809,7 +1809,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -1905,7 +1905,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1913,7 +1913,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -2006,7 +2006,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2014,7 +2014,7 @@ class LegacyGetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val 
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse2>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/legacy/LegacyGetInternationalPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/legacy/LegacyGetInternationalPaymentTest.kt
@@ -58,7 +58,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -66,7 +66,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -163,7 +163,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -171,7 +171,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -266,7 +266,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -274,7 +274,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -372,7 +372,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -380,7 +380,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -482,7 +482,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -490,7 +490,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -593,7 +593,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -601,7 +601,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -700,7 +700,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -708,7 +708,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -806,7 +806,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -814,7 +814,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -909,7 +909,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -917,7 +917,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -1013,7 +1013,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1021,7 +1021,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1119,7 +1119,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1127,7 +1127,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1224,7 +1224,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1232,7 +1232,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1326,7 +1326,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1334,7 +1334,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1430,7 +1430,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1438,7 +1438,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1540,7 +1540,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1548,7 +1548,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1650,7 +1650,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1658,7 +1658,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1756,7 +1756,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1764,7 +1764,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1864,7 +1864,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1872,7 +1872,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -1970,7 +1970,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1978,7 +1978,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -2075,7 +2075,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2083,7 +2083,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -2177,7 +2177,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2185,7 +2185,7 @@ class LegacyGetInternationalPaymentTest(val tppResource: CreateTppCallback.TppRe
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalConsentResponse2>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
@@ -17,6 +17,7 @@ import com.forgerock.uk.openbanking.framework.errors.INVALID_FORMAT_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.errors.NO_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.errors.PAYMENT_SUBMISSION_ALREADY_EXISTS
 import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
@@ -31,6 +32,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
 
     private val createInternationalScheduledPaymentsConsents =
         CreateInternationalScheduledPaymentsConsents(version, tppResource)
+    private val paymentLinks = getPaymentsApiLinks(version)
 
     fun createInternationalScheduledPayment_rateType_AGREED_Test() {
         // Given
@@ -49,7 +51,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -80,7 +82,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
 
         // When
         val result = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+            paymentLinks.CreateInternationalScheduledPayment,
             paymentSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -115,7 +117,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -146,7 +148,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
 
         // When
         val result = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+            paymentLinks.CreateInternationalScheduledPayment,
             paymentSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -180,7 +182,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -211,7 +213,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
 
         // When
         val result = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+            paymentLinks.CreateInternationalScheduledPayment,
             paymentSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -240,7 +242,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -271,7 +273,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
 
         // When
         val result = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+            paymentLinks.CreateInternationalScheduledPayment,
             paymentSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -301,7 +303,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -329,7 +331,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
             tppResource.tpp.signingKid
         )
         val result = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+            paymentLinks.CreateInternationalScheduledPayment,
             paymentSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -340,7 +342,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-                createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+                paymentLinks.CreateInternationalScheduledPayment,
                 paymentSubmissionRequest,
                 accessTokenAuthorizationCode,
                 signedPayload,
@@ -371,7 +373,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -396,7 +398,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-                createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+                paymentLinks.CreateInternationalScheduledPayment,
                 paymentSubmissionRequest,
                 accessTokenAuthorizationCode,
                 INVALID_FORMAT_DETACHED_JWS,
@@ -427,7 +429,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -453,7 +455,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().submitPaymentNoDetachedJws<OBWriteInternationalScheduledResponse5>(
-                createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+                paymentLinks.CreateInternationalScheduledPayment,
                 paymentSubmissionRequest,
                 accessTokenAuthorizationCode
             )
@@ -481,7 +483,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -514,7 +516,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-                createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+                paymentLinks.CreateInternationalScheduledPayment,
                 paymentSubmissionRequest,
                 accessTokenAuthorizationCode,
                 signedPayload,
@@ -545,7 +547,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -577,7 +579,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-                createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+                paymentLinks.CreateInternationalScheduledPayment,
                 paymentSubmissionRequest,
                 accessTokenAuthorizationCode,
                 signedPayload,
@@ -607,7 +609,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -649,7 +651,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-                createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+                paymentLinks.CreateInternationalScheduledPayment,
                 paymentSubmissionRequest,
                 accessTokenAuthorizationCode,
                 signedPayload,
@@ -679,7 +681,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp
@@ -721,7 +723,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
             PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-                createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+                paymentLinks.CreateInternationalScheduledPayment,
                 paymentSubmissionRequest,
                 accessTokenAuthorizationCode,
                 signedPayload,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
@@ -6,25 +6,29 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.conditions.Status
+import com.forgerock.securebanking.framework.data.AccessToken
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.http.fuel.defaultMapper
-import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.framework.constants.INVALID_CONSENT_ID
-import com.forgerock.uk.openbanking.framework.constants.INVALID_FORMAT_DETACHED_JWS
-import com.forgerock.uk.openbanking.framework.constants.INVALID_SIGNING_KID
 import com.forgerock.uk.openbanking.framework.errors.INVALID_FORMAT_DETACHED_JWS_ERROR
 import com.forgerock.uk.openbanking.framework.errors.NO_DETACHED_JWS
 import com.forgerock.uk.openbanking.framework.errors.PAYMENT_SUBMISSION_ALREADY_EXISTS
 import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
-import com.forgerock.uk.openbanking.support.payment.PaymentFactory
+import com.forgerock.uk.openbanking.support.payment.BadJwsSignatureProducer
+import com.forgerock.uk.openbanking.support.payment.DefaultJwsSignatureProducer
+import com.forgerock.uk.openbanking.support.payment.InvalidKidJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.consents.api.v3_1_8.CreateInternationalScheduledPaymentsConsents
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3Data
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse6
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledResponse5
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5MandatoryFields
 
@@ -33,6 +37,8 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
     private val createInternationalScheduledPaymentsConsents =
         CreateInternationalScheduledPaymentsConsents(version, tppResource)
     private val paymentLinks = getPaymentsApiLinks(version)
+    private val createPaymentUrl = paymentLinks.CreateInternationalScheduledPayment
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun createInternationalScheduledPayment_rateType_AGREED_Test() {
         // Given
@@ -40,55 +46,8 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
             OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
         consentRequest.data.initiation.exchangeRateInformation.rateType = OBExchangeRateType2Code.AGREED
 
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.data.initiation).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    PaymentFactory.mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
         // When
-        val result = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            paymentLinks.CreateInternationalScheduledPayment,
-            paymentSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
+        val result = submitPayment(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -105,56 +64,8 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         consentRequest.data.initiation.exchangeRateInformation.exchangeRate = null
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
 
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
-            consentRequest
-        )
-
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.data.initiation).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    PaymentFactory.mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
         // When
-        val result = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            paymentLinks.CreateInternationalScheduledPayment,
-            paymentSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
+        val result = submitPayment(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -170,56 +81,8 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         consentRequest.data.initiation.exchangeRateInformation.exchangeRate = null
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
 
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
-            consentRequest
-        )
-
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.data.initiation).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    PaymentFactory.mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
         // When
-        val result = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            paymentLinks.CreateInternationalScheduledPayment,
-            paymentSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
+        val result = submitPayment(consentRequest)
 
         // Then
         assertThat(result).isNotNull()
@@ -230,57 +93,8 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
     fun createInternationalScheduledPayment_mandatoryFields_Test() {
         // Given
         val consentRequest = aValidOBWriteInternationalScheduledConsent5MandatoryFields()
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
-            consentRequest
-        )
-
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.data.initiation).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
         // When
-        val result = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            paymentLinks.CreateInternationalScheduledPayment,
-            paymentSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
+        val result = submitPayment(consentRequest)
         // Then
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
@@ -291,64 +105,24 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         // Given
         val consentRequest =
             OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
+        val (consent, authorizationToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
-
 
         assertThat(consent).isNotNull()
         assertThat(consent.data).isNotNull()
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    PaymentFactory.mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-        val result = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            paymentLinks.CreateInternationalScheduledPayment,
-            paymentSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
+        // When
+        val patchedConsent = getPatchedConsent(consent)
+        // Submit first payment
+        submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-                paymentLinks.CreateInternationalScheduledPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode,
-                signedPayload,
-                tppResource.tpp,
-                version
-            )
+            // Verify we fail to submit a second payment
+            submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
         }
 
         // Then
@@ -361,50 +135,21 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         val consentRequest =
             OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
 
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
+        val (consent, accessToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
-
 
         assertThat(consent).isNotNull()
         assertThat(consent.data).isNotNull()
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
+        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-                paymentLinks.CreateInternationalScheduledPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode,
-                INVALID_FORMAT_DETACHED_JWS,
-                tppResource.tpp,
-                version
-            )
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
+                .configureJwsSignatureProducer(BadJwsSignatureProducer()).sendRequest()
         }
 
         // Then
@@ -417,48 +162,21 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         val consentRequest =
             OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
 
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
+        val (consent, accessToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
-
 
         assertThat(consent).isNotNull()
         assertThat(consent.data).isNotNull()
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
+        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPaymentNoDetachedJws<OBWriteInternationalScheduledResponse5>(
-                paymentLinks.CreateInternationalScheduledPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode
-            )
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
+                .configureJwsSignatureProducer(null).sendRequest()
         }
 
         // Then
@@ -471,58 +189,21 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         val consentRequest =
             OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
 
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
+        val (consent, accessToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
-
 
         assertThat(consent).isNotNull()
         assertThat(consent.data).isNotNull()
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
-
-        val signedPayload =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(paymentSubmissionRequest),
-                tppResource.tpp.signingKey,
-                tppResource.tpp.signingKid,
-                true
-            )
+        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-                paymentLinks.CreateInternationalScheduledPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode,
-                signedPayload,
-                tppResource.tpp,
-                version
-            )
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
+                .configureJwsSignatureProducer(DefaultJwsSignatureProducer(tppResource.tpp, false)).sendRequest()
         }
 
         // Then
@@ -535,57 +216,21 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         val consentRequest =
             OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
 
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
+        val (consent, accessToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
-
 
         assertThat(consent).isNotNull()
         assertThat(consent.data).isNotNull()
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
-
-        val signedPayload =
-            signPayloadSubmitPayment(
-                defaultMapper.writeValueAsString(paymentSubmissionRequest),
-                tppResource.tpp.signingKey,
-                INVALID_SIGNING_KID
-            )
+        val paymentSubmissionRequest = createPaymentRequest(getPatchedConsent(consent))
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-                paymentLinks.CreateInternationalScheduledPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode,
-                signedPayload,
-                tppResource.tpp,
-                version
-            )
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
+                .configureJwsSignatureProducer(InvalidKidJwsSignatureProducer(tppResource.tpp)).sendRequest()
         }
 
         // Then
@@ -597,8 +242,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         // Given
         val consentRequest =
             OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
-
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
+        val (consent, accessToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
 
@@ -607,57 +251,20 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
+        val patchedConsent = getPatchedConsent(consent)
+        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
 
         patchedConsent.data.consentId = INVALID_CONSENT_ID
-        val paymentSubmissionWithInvalidConsentId = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
+        val paymentSubmissionWithInvalidConsentId = createPaymentRequest(patchedConsent)
 
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionWithInvalidConsentId),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
+        val signatureWithInvalidConsentId = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
+            defaultMapper.writeValueAsString(paymentSubmissionWithInvalidConsentId)
         )
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-                paymentLinks.CreateInternationalScheduledPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode,
-                signedPayload,
-                tppResource.tpp,
-                version
-            )
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
+                .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidConsentId)).sendRequest()
         }
 
         // Then
@@ -670,7 +277,7 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         val consentRequest =
             OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
 
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
+        val (consent, accessToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
             consentRequest
         )
 
@@ -679,61 +286,67 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
         assertThat(consent.data.consentId).isNotEmpty()
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val paymentSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
+        val patchedConsent = getPatchedConsent(consent)
+        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
 
         patchedConsent.data.initiation.instructedAmount.amount = "123123"
-        val paymentSubmissionInvalidAmount = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
+        val paymentSubmissionInvalidAmount = createPaymentRequest(patchedConsent)
 
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(paymentSubmissionInvalidAmount),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
+        val signatureWithInvalidAmount = DefaultJwsSignatureProducer(tppResource.tpp).createDetachedSignature(
+            defaultMapper.writeValueAsString(paymentSubmissionInvalidAmount)
         )
 
         // When
         val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
-            PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-                paymentLinks.CreateInternationalScheduledPayment,
-                paymentSubmissionRequest,
-                accessTokenAuthorizationCode,
-                signedPayload,
-                tppResource.tpp,
-                version
-            )
+            paymentApiClient.buildSubmitPaymentRequest(createPaymentUrl, accessToken, paymentSubmissionRequest)
+                .configureJwsSignatureProducer(BadJwsSignatureProducer(signatureWithInvalidAmount)).sendRequest()
         }
 
         // Then
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
         assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+    }
+
+    fun submitPayment(consentRequest: OBWriteInternationalScheduledConsent5): OBWriteInternationalScheduledResponse5 {
+        val (consent, authorizationToken) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndAuthorize(
+            consentRequest
+        )
+        return submitPayment(consent, authorizationToken)
+    }
+
+    fun submitPayment(
+        consentResponse: OBWriteInternationalScheduledConsentResponse6,
+        authorizationToken: AccessToken
+    ): OBWriteInternationalScheduledResponse5 {
+        val patchedConsent = getPatchedConsent(consentResponse)
+        return submitPaymentForPatchedConsent(patchedConsent, authorizationToken)
+    }
+
+    private fun getPatchedConsent(consent: OBWriteInternationalScheduledConsentResponse6): OBWriteInternationalScheduledConsentResponse6 {
+        return createInternationalScheduledPaymentsConsents.getPatchedConsent(consent)
+    }
+
+    private fun submitPaymentForPatchedConsent(
+        patchedConsent: OBWriteInternationalScheduledConsentResponse6,
+        authorizationToken: AccessToken
+    ): OBWriteInternationalScheduledResponse5 {
+        val paymentSubmissionRequest = createPaymentRequest(patchedConsent)
+        return paymentApiClient.submitPayment(
+            createPaymentUrl,
+            authorizationToken,
+            paymentSubmissionRequest
+        )
+    }
+
+    private fun createPaymentRequest(patchedConsent: OBWriteInternationalScheduledConsentResponse6): OBWriteInternationalScheduled3 {
+        return OBWriteInternationalScheduled3().data(
+            OBWriteInternationalScheduled3Data()
+                .consentId(patchedConsent.data.consentId)
+                .initiation(
+                    mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
+                        patchedConsent.data.initiation
+                    )
+                )
+            )
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPayment.kt
@@ -1,101 +1,36 @@
 package com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.api.v3_1_8
 
 import assertk.assertThat
-import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
-import com.forgerock.securebanking.framework.http.fuel.defaultMapper
-import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
-import com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.consents.api.v3_1_8.CreateInternationalScheduledPaymentsConsents
+import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.*
+import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code
+import uk.org.openbanking.datamodel.payment.OBReadRefundAccountEnum
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledResponse5
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory
 
 class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
 
-    private val createInternationalScheduledPaymentsConsents =
-        CreateInternationalScheduledPaymentsConsents(version, tppResource)
+    private val createInternationalScheduledPayment =
+        CreateInternationalScheduledPayment(version, tppResource)
     private val paymentLinks = getPaymentsApiLinks(version)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun getInternationalScheduledPayments_rateType_AGREED_Test() {
         // Given
         val consentRequest =
             OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
         consentRequest.data.initiation.exchangeRateInformation.rateType = OBExchangeRateType2Code.AGREED
-
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        assertThat(consent.data.initiation.exchangeRateInformation.exchangeRate).isNotNull()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    PaymentFactory.mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            paymentLinks.CreateInternationalScheduledPayment,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.internationalScheduledPaymentId).isNotEmpty()
+        val paymentResponse = createInternationalScheduledPayment.submitPayment(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWriteInternationalScheduledResponse5>(
-            PaymentFactory.urlWithInternationalScheduledPaymentId(
-                paymentLinks.GetInternationalScheduledPayment,
-                submissionResponse.data.internationalScheduledPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val result = getInternationalScheduledPayment(paymentResponse)
 
         // Then
         assertThat(result).isNotNull()
@@ -113,72 +48,10 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         consentRequest.data.initiation.exchangeRateInformation.exchangeRate = null
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
 
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    PaymentFactory.mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            paymentLinks.CreateInternationalScheduledPayment,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.internationalScheduledPaymentId).isNotEmpty()
+        val paymentResponse = createInternationalScheduledPayment.submitPayment(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWriteInternationalScheduledResponse5>(
-            PaymentFactory.urlWithInternationalScheduledPaymentId(
-                paymentLinks.GetInternationalScheduledPayment,
-                submissionResponse.data.internationalScheduledPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val result = getInternationalScheduledPayment(paymentResponse)
 
         // Then
         assertThat(result).isNotNull()
@@ -195,72 +68,10 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         consentRequest.data.initiation.exchangeRateInformation.exchangeRate = null
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
 
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    PaymentFactory.mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            paymentLinks.CreateInternationalScheduledPayment,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.internationalScheduledPaymentId).isNotEmpty()
+        val paymentResponse = createInternationalScheduledPayment.submitPayment(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWriteInternationalScheduledResponse5>(
-            PaymentFactory.urlWithInternationalScheduledPaymentId(
-                paymentLinks.GetInternationalScheduledPayment,
-                submissionResponse.data.internationalScheduledPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val result = getInternationalScheduledPayment(paymentResponse)
 
         // Then
         assertThat(result).isNotNull()
@@ -274,72 +85,10 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         val consentRequest =
             OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5MandatoryFields()
 
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    PaymentFactory.mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            paymentLinks.CreateInternationalScheduledPayment,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.internationalScheduledPaymentId).isNotEmpty()
+        val paymentResponse = createInternationalScheduledPayment.submitPayment(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWriteInternationalScheduledResponse5>(
-            PaymentFactory.urlWithInternationalScheduledPaymentId(
-                paymentLinks.GetInternationalScheduledPayment,
-                submissionResponse.data.internationalScheduledPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val result = getInternationalScheduledPayment(paymentResponse)
 
         // Then
         assertThat(result).isNotNull()
@@ -354,74 +103,10 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
             OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
         consentRequest.data.readRefundAccount = OBReadRefundAccountEnum.YES
 
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        assertThat(consent.data.readRefundAccount).isEqualTo(OBReadRefundAccountEnum.YES)
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        assertThat(patchedConsent.data.readRefundAccount).isEqualTo(OBReadRefundAccountEnum.YES)
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    PaymentFactory.mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            paymentLinks.CreateInternationalScheduledPayment,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.internationalScheduledPaymentId).isNotEmpty()
+        val paymentResponse = createInternationalScheduledPayment.submitPayment(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWriteInternationalScheduledResponse5>(
-            PaymentFactory.urlWithInternationalScheduledPaymentId(
-                paymentLinks.GetInternationalScheduledPayment,
-                submissionResponse.data.internationalScheduledPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val result = getInternationalScheduledPayment(paymentResponse)
 
         // Then
         assertThat(result).isNotNull()
@@ -430,5 +115,16 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         //TODO: Waiting for the fix from the issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/241
 //        assertThat(result.data.refund.account.identification).isEqualTo(consent.data.initiation.debtorAccount.identification)
         Assertions.assertThat(result.data.status.toString()).`is`(Status.paymentCondition)
+    }
+
+    private fun getInternationalScheduledPayment(paymentResponse: OBWriteInternationalScheduledResponse5): OBWriteInternationalScheduledResponse5 {
+        val getDomesticPaymentUrl = PaymentFactory.urlWithInternationalScheduledPaymentId(
+            paymentLinks.GetInternationalPayment,
+            paymentResponse.data.internationalScheduledPaymentId
+        )
+        return paymentApiClient.sendGetRequest(
+            getDomesticPaymentUrl,
+            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
+        )
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPayment.kt
@@ -38,7 +38,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
@@ -121,7 +121,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
@@ -203,7 +203,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
@@ -282,7 +282,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
@@ -363,7 +363,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPayment.kt
@@ -119,7 +119,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
 
     private fun getInternationalScheduledPayment(paymentResponse: OBWriteInternationalScheduledResponse5): OBWriteInternationalScheduledResponse5 {
         val getDomesticPaymentUrl = PaymentFactory.urlWithInternationalScheduledPaymentId(
-            paymentLinks.GetInternationalPayment,
+            paymentLinks.GetInternationalScheduledPayment,
             paymentResponse.data.internationalScheduledPaymentId
         )
         return paymentApiClient.sendGetRequest(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPayment.kt
@@ -9,6 +9,7 @@ import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.http.fuel.defaultMapper
 import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.consents.api.v3_1_8.CreateInternationalScheduledPaymentsConsents
@@ -20,6 +21,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
 
     private val createInternationalScheduledPaymentsConsents =
         CreateInternationalScheduledPaymentsConsents(version, tppResource)
+    private val paymentLinks = getPaymentsApiLinks(version)
 
     fun getInternationalScheduledPayments_rateType_AGREED_Test() {
         // Given
@@ -42,7 +44,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -72,7 +74,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         )
 
         val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+            paymentLinks.CreateInternationalScheduledPayment,
             standingOrderSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -88,7 +90,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         // When
         val result = PaymentRS().getPayment<OBWriteInternationalScheduledResponse5>(
             PaymentFactory.urlWithInternationalScheduledPaymentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPayment,
+                paymentLinks.GetInternationalScheduledPayment,
                 submissionResponse.data.internationalScheduledPaymentId
             ),
             accessTokenClientCredentials,
@@ -125,7 +127,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -155,7 +157,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         )
 
         val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+            paymentLinks.CreateInternationalScheduledPayment,
             standingOrderSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -171,7 +173,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         // When
         val result = PaymentRS().getPayment<OBWriteInternationalScheduledResponse5>(
             PaymentFactory.urlWithInternationalScheduledPaymentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPayment,
+                paymentLinks.GetInternationalScheduledPayment,
                 submissionResponse.data.internationalScheduledPaymentId
             ),
             accessTokenClientCredentials,
@@ -207,7 +209,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -237,7 +239,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         )
 
         val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+            paymentLinks.CreateInternationalScheduledPayment,
             standingOrderSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -253,7 +255,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         // When
         val result = PaymentRS().getPayment<OBWriteInternationalScheduledResponse5>(
             PaymentFactory.urlWithInternationalScheduledPaymentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPayment,
+                paymentLinks.GetInternationalScheduledPayment,
                 submissionResponse.data.internationalScheduledPaymentId
             ),
             accessTokenClientCredentials,
@@ -286,7 +288,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -316,7 +318,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         )
 
         val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+            paymentLinks.CreateInternationalScheduledPayment,
             standingOrderSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -332,7 +334,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         // When
         val result = PaymentRS().getPayment<OBWriteInternationalScheduledResponse5>(
             PaymentFactory.urlWithInternationalScheduledPaymentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPayment,
+                paymentLinks.GetInternationalScheduledPayment,
                 submissionResponse.data.internationalScheduledPaymentId
             ),
             accessTokenClientCredentials,
@@ -367,7 +369,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -398,7 +400,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         )
 
         val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+            paymentLinks.CreateInternationalScheduledPayment,
             standingOrderSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -414,7 +416,7 @@ class GetInternationalScheduledPayment(val version: OBVersion, val tppResource: 
         // When
         val result = PaymentRS().getPayment<OBWriteInternationalScheduledResponse5>(
             PaymentFactory.urlWithInternationalScheduledPaymentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPayment,
+                paymentLinks.GetInternationalScheduledPayment,
                 submissionResponse.data.internationalScheduledPaymentId
             ),
             accessTokenClientCredentials,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails.kt
@@ -1,29 +1,25 @@
 package com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.api.v3_1_8
 
 import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
-import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
-import com.forgerock.securebanking.framework.http.fuel.defaultMapper
-import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
-import com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.consents.api.v3_1_8.CreateInternationalScheduledPaymentsConsents
-import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.*
+import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
+import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledResponse5
+import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory
 
 class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails(
     val version: OBVersion,
     val tppResource: CreateTppCallback.TppResource
 ) {
-    private val createInternationalScheduledPaymentsConsents =
-        CreateInternationalScheduledPaymentsConsents(version, tppResource)
+    private val createInternationalScheduledPayment =
+        CreateInternationalScheduledPayment(version, tppResource)
     private val paymentLinks = getPaymentsApiLinks(version)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
     
     fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_AGREED_Test() {
         // Given
@@ -31,73 +27,10 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
             OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
         consentRequest.data.initiation.exchangeRateInformation.rateType = OBExchangeRateType2Code.AGREED
 
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        assertThat(consent.data.initiation.exchangeRateInformation.exchangeRate).isNotNull()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    PaymentFactory.mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            paymentLinks.CreateInternationalScheduledPayment,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.internationalScheduledPaymentId).isNotEmpty()
+        val paymentResponse = createInternationalScheduledPayment.submitPayment(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
-            PaymentFactory.urlWithInternationalScheduledPaymentId(
-                paymentLinks.GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails,
-                submissionResponse.data.internationalScheduledPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val result = getPaymentDetails(paymentResponse)
 
         // Then
         assertThat(result).isNotNull()
@@ -113,72 +46,10 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         consentRequest.data.initiation.exchangeRateInformation.exchangeRate = null
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
 
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    PaymentFactory.mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            paymentLinks.CreateInternationalScheduledPayment,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.internationalScheduledPaymentId).isNotEmpty()
+        val paymentResponse = createInternationalScheduledPayment.submitPayment(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
-            PaymentFactory.urlWithInternationalScheduledPaymentId(
-                paymentLinks.GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails,
-                submissionResponse.data.internationalScheduledPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val result = getPaymentDetails(paymentResponse)
 
         // Then
         assertThat(result).isNotNull()
@@ -194,72 +65,10 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         consentRequest.data.initiation.exchangeRateInformation.exchangeRate = null
         consentRequest.data.initiation.exchangeRateInformation.contractIdentification = null
 
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    PaymentFactory.mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            paymentLinks.CreateInternationalScheduledPayment,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.internationalScheduledPaymentId).isNotEmpty()
+        val paymentResponse = createInternationalScheduledPayment.submitPayment(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
-            PaymentFactory.urlWithInternationalScheduledPaymentId(
-                paymentLinks.GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails,
-                submissionResponse.data.internationalScheduledPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val result = getPaymentDetails(paymentResponse)
 
         // Then
         assertThat(result).isNotNull()
@@ -272,76 +81,25 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         val consentRequest =
             OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5MandatoryFields()
 
-        val (consent, accessTokenAuthorizationCode) = createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsentAndGetAccessToken(
-            consentRequest
-        )
-
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-
-        // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
-
-        val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(patchedConsent).isNotNull()
-        assertThat(patchedConsent.data).isNotNull()
-        assertThat(patchedConsent.risk).isNotNull()
-        assertThat(patchedConsent.data.consentId).isNotEmpty()
-        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
-
-        val standingOrderSubmissionRequest = OBWriteInternationalScheduled3().data(
-            OBWriteInternationalScheduled3Data()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(
-                    PaymentFactory.mapOBWriteInternationalScheduledConsentResponse6DataInitiationToOBWriteInternationalScheduled3DataInitiation(
-                        patchedConsent.data.initiation
-                    )
-                )
-        ).risk(patchedConsent.risk)
-
-        val signedPayload = signPayloadSubmitPayment(
-            defaultMapper.writeValueAsString(standingOrderSubmissionRequest),
-            tppResource.tpp.signingKey,
-            tppResource.tpp.signingKid
-        )
-
-        val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            paymentLinks.CreateInternationalScheduledPayment,
-            standingOrderSubmissionRequest,
-            accessTokenAuthorizationCode,
-            signedPayload,
-            tppResource.tpp,
-            version
-        )
-
-        assertThat(submissionResponse).isNotNull()
-        assertThat(submissionResponse.data).isNotNull()
-        assertThat(submissionResponse.data.consentId).isEqualTo(patchedConsent.data.consentId)
-        assertThat(submissionResponse.data.internationalScheduledPaymentId).isNotEmpty()
+        val paymentResponse = createInternationalScheduledPayment.submitPayment(consentRequest)
 
         // When
-        val result = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
-            PaymentFactory.urlWithInternationalScheduledPaymentId(
-                paymentLinks.GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails,
-                submissionResponse.data.internationalScheduledPaymentId
-            ),
-            accessTokenClientCredentials,
-            tppResource.tpp
-        )
+        val result = getPaymentDetails(paymentResponse)
 
         // Then
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.paymentStatus).isNotNull()
+    }
+
+    private fun getPaymentDetails(paymentResponse: OBWriteInternationalScheduledResponse5): OBWritePaymentDetailsResponse1 {
+        val getInternationalPaymentDetails = PaymentFactory.urlWithInternationalPaymentId(
+            paymentLinks.GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails,
+            paymentResponse.data.internationalScheduledPaymentId
+        )
+        return paymentApiClient.sendGetRequest(
+            getInternationalPaymentDetails,
+            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
+        )
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails.kt
@@ -9,6 +9,7 @@ import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.http.fuel.defaultMapper
 import com.forgerock.securebanking.framework.signature.signPayloadSubmitPayment
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.consents.api.v3_1_8.CreateInternationalScheduledPaymentsConsents
@@ -20,10 +21,10 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
     val version: OBVersion,
     val tppResource: CreateTppCallback.TppResource
 ) {
-
     private val createInternationalScheduledPaymentsConsents =
         CreateInternationalScheduledPaymentsConsents(version, tppResource)
-
+    private val paymentLinks = getPaymentsApiLinks(version)
+    
     fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_AGREED_Test() {
         // Given
         val consentRequest =
@@ -45,7 +46,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -75,7 +76,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         )
 
         val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+            paymentLinks.CreateInternationalScheduledPayment,
             standingOrderSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -91,7 +92,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         // When
         val result = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
             PaymentFactory.urlWithInternationalScheduledPaymentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails,
+                paymentLinks.GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails,
                 submissionResponse.data.internationalScheduledPaymentId
             ),
             accessTokenClientCredentials,
@@ -126,7 +127,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -156,7 +157,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         )
 
         val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+            paymentLinks.CreateInternationalScheduledPayment,
             standingOrderSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -172,7 +173,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         // When
         val result = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
             PaymentFactory.urlWithInternationalScheduledPaymentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails,
+                paymentLinks.GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails,
                 submissionResponse.data.internationalScheduledPaymentId
             ),
             accessTokenClientCredentials,
@@ -207,7 +208,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -237,7 +238,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         )
 
         val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+            paymentLinks.CreateInternationalScheduledPayment,
             standingOrderSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -253,7 +254,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         // When
         val result = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
             PaymentFactory.urlWithInternationalScheduledPaymentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails,
+                paymentLinks.GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails,
                 submissionResponse.data.internationalScheduledPaymentId
             ),
             accessTokenClientCredentials,
@@ -285,7 +286,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -315,7 +316,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         )
 
         val submissionResponse = PaymentRS().submitPayment<OBWriteInternationalScheduledResponse5>(
-            createInternationalScheduledPaymentsConsents.paymentLinks.CreateInternationalScheduledPayment,
+            paymentLinks.CreateInternationalScheduledPayment,
             standingOrderSubmissionRequest,
             accessTokenAuthorizationCode,
             signedPayload,
@@ -331,7 +332,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         // When
         val result = PaymentRS().getPayment<OBWritePaymentDetailsResponse1>(
             PaymentFactory.urlWithInternationalScheduledPaymentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails,
+                paymentLinks.GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails,
                 submissionResponse.data.internationalScheduledPaymentId
             ),
             accessTokenClientCredentials,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails.kt
@@ -41,7 +41,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
@@ -122,7 +122,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
@@ -203,7 +203,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
@@ -281,7 +281,7 @@ class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDeta
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/CreateInternationalScheduledPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/CreateInternationalScheduledPaymentsConsents.kt
@@ -37,8 +37,7 @@ class CreateInternationalScheduledPaymentsConsents(
     val version: OBVersion,
     val tppResource: CreateTppCallback.TppResource
 ) {
-
-    val paymentLinks = getPaymentsApiLinks(version)
+    private val paymentLinks = getPaymentsApiLinks(version)
     private val paymentApiClient = tppResource.tpp.paymentApiClient
 
     fun createInternationalScheduledPaymentsConsentsTest() {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/CreateInternationalScheduledPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/CreateInternationalScheduledPaymentsConsents.kt
@@ -143,7 +143,7 @@ class CreateInternationalScheduledPaymentsConsents(
 
     private fun buildCreateConsentRequest(
         consent: OBWriteInternationalScheduledConsent5
-    ) = paymentApiClient.createDefaultPostRequest(
+    ) = paymentApiClient.newPostRequestBuilder(
         paymentLinks.CreateInternationalScheduledPaymentConsent,
         tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken),
         consent

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/GetInternationalScheduledPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/GetInternationalScheduledPaymentsConsents.kt
@@ -7,6 +7,7 @@ import assertk.assertions.isNotNull
 import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
@@ -18,9 +19,9 @@ class GetInternationalScheduledPaymentsConsents(
     val version: OBVersion,
     val tppResource: CreateTppCallback.TppResource
 ) {
-
     private val createInternationalScheduledPaymentsConsents =
         CreateInternationalScheduledPaymentsConsents(version, tppResource)
+    private val paymentLinks = getPaymentsApiLinks(version)
 
     fun shouldGetInternationalScheduledPaymentsConsents_rateType_AGREED_Test() {
         // Given
@@ -41,7 +42,7 @@ class GetInternationalScheduledPaymentsConsents(
         // When
         val result = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -76,7 +77,7 @@ class GetInternationalScheduledPaymentsConsents(
         // When
         val result = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,
@@ -111,7 +112,7 @@ class GetInternationalScheduledPaymentsConsents(
         // When
         val result = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
             PaymentFactory.urlWithConsentId(
-                createInternationalScheduledPaymentsConsents.paymentLinks.GetInternationalScheduledPaymentConsent,
+                paymentLinks.GetInternationalScheduledPaymentConsent,
                 consent.data.consentId
             ),
             tppResource.tpp,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/GetInternationalScheduledPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/GetInternationalScheduledPaymentsConsents.kt
@@ -2,17 +2,11 @@ package com.forgerock.uk.openbanking.tests.functional.payment.international.sche
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
-import com.forgerock.securebanking.framework.conditions.Status
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
-import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentRS
-import org.assertj.core.api.Assertions
 import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse6
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory
 
 class GetInternationalScheduledPaymentsConsents(
@@ -32,22 +26,8 @@ class GetInternationalScheduledPaymentsConsents(
         val consent =
             createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsent(consentRequest)
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-        assertThat(consent.data.initiation.exchangeRateInformation.exchangeRate).isNotNull()
-
         // When
-        val result = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
+        val result = createInternationalScheduledPaymentsConsents.getPatchedConsent(consent)
 
         // Then
         assertThat(result).isNotNull()
@@ -68,21 +48,8 @@ class GetInternationalScheduledPaymentsConsents(
         val consent =
             createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsent(consentRequest)
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-
         // When
-        val result = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
+        val result = createInternationalScheduledPaymentsConsents.getPatchedConsent(consent)
 
         // Then
         assertThat(result).isNotNull()
@@ -103,21 +70,8 @@ class GetInternationalScheduledPaymentsConsents(
         val consent =
             createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentConsent(consentRequest)
 
-        assertThat(consent).isNotNull()
-        assertThat(consent.data).isNotNull()
-        assertThat(consent.data.consentId).isNotEmpty()
-        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
-        assertThat(consent.risk).isNotNull()
-
         // When
-        val result = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse6>(
-            PaymentFactory.urlWithConsentId(
-                paymentLinks.GetInternationalScheduledPaymentConsent,
-                consent.data.consentId
-            ),
-            tppResource.tpp,
-            version
-        )
+        val result = createInternationalScheduledPaymentsConsents.getPatchedConsent(consent)
 
         // Then
         assertThat(result).isNotNull()

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/legacy/LegacyCreateInternationalScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/legacy/LegacyCreateInternationalScheduledPaymentTest.kt
@@ -67,7 +67,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -153,7 +153,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -238,7 +238,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -320,7 +320,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -403,7 +403,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -492,7 +492,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -570,7 +570,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -645,7 +645,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -730,7 +730,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -814,7 +814,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -904,7 +904,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -995,7 +995,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1082,7 +1082,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1168,7 +1168,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1251,7 +1251,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1335,7 +1335,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1427,7 +1427,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1504,7 +1504,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1578,7 +1578,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1663,7 +1663,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1746,7 +1746,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1829,7 +1829,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1919,7 +1919,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2010,7 +2010,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2101,7 +2101,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2191,7 +2191,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2278,7 +2278,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2366,7 +2366,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2462,7 +2462,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2543,7 +2543,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2621,7 +2621,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2710,7 +2710,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2797,7 +2797,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2884,7 +2884,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2982,7 +2982,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3081,7 +3081,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3173,7 +3173,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3264,7 +3264,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3352,7 +3352,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3441,7 +3441,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3537,7 +3537,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3617,7 +3617,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3695,7 +3695,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3783,7 +3783,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3871,7 +3871,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -3959,7 +3959,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4057,7 +4057,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4156,7 +4156,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4244,7 +4244,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4331,7 +4331,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4415,7 +4415,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4500,7 +4500,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4594,7 +4594,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4671,7 +4671,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4745,7 +4745,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4830,7 +4830,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4914,7 +4914,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -4998,7 +4998,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -5088,7 +5088,7 @@ class LegacyCreateInternationalScheduledPaymentTest(val tppResource: CreateTppCa
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/legacy/LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/legacy/LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetailsTest.kt
@@ -57,7 +57,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -65,7 +65,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -159,7 +159,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -167,7 +167,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -261,7 +261,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -269,7 +269,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -360,7 +360,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -368,7 +368,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -461,7 +461,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -469,7 +469,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -565,7 +565,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -573,7 +573,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -669,7 +669,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -677,7 +677,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -770,7 +770,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -778,7 +778,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -873,7 +873,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -881,7 +881,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -981,7 +981,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -989,7 +989,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1089,7 +1089,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1097,7 +1097,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1194,7 +1194,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1202,7 +1202,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1301,7 +1301,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1309,7 +1309,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -1405,7 +1405,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1413,7 +1413,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -1509,7 +1509,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1517,7 +1517,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -1610,7 +1610,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1618,7 +1618,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -1713,7 +1713,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1721,7 +1721,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -1817,7 +1817,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1825,7 +1825,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -1921,7 +1921,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1929,7 +1929,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -2022,7 +2022,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2030,7 +2030,7 @@ class LegacyGetInternationalScheduledPaymentInternationalScheduledPaymentIdPayme
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse2>(
             PaymentFactory.urlWithConsentId(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/legacy/LegacyGetInternationalScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/legacy/LegacyGetInternationalScheduledPaymentTest.kt
@@ -58,7 +58,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -66,7 +66,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -163,7 +163,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -171,7 +171,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -266,7 +266,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -274,7 +274,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -372,7 +372,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -380,7 +380,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -482,7 +482,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -490,7 +490,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse5>(
             PaymentFactory.urlWithConsentId(
@@ -593,7 +593,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -601,7 +601,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -700,7 +700,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -708,7 +708,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -806,7 +806,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -814,7 +814,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -909,7 +909,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -917,7 +917,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse4>(
             PaymentFactory.urlWithConsentId(
@@ -1013,7 +1013,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1021,7 +1021,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1123,7 +1123,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1131,7 +1131,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1232,7 +1232,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1240,7 +1240,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1338,7 +1338,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1346,7 +1346,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1446,7 +1446,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1454,7 +1454,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1556,7 +1556,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1564,7 +1564,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1666,7 +1666,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1674,7 +1674,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1772,7 +1772,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1780,7 +1780,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse3>(
             PaymentFactory.urlWithConsentId(
@@ -1880,7 +1880,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1888,7 +1888,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -1986,7 +1986,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -1994,7 +1994,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -2091,7 +2091,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2099,7 +2099,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse2>(
             PaymentFactory.urlWithConsentId(
@@ -2193,7 +2193,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
 
         // accessToken to submit payment use the grant type authorization_code
-        val accessTokenAuthorizationCode = PaymentAS().getAccessToken(
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
@@ -2201,7 +2201,7 @@ class LegacyGetInternationalScheduledPaymentTest(val tppResource: CreateTppCallb
         )
 
         // accessToken to get the payment use the grant type client_credentials
-        val accessTokenClientCredentials = PaymentRS().getAccessToken(tppResource.tpp)
+        val accessTokenClientCredentials = PaymentRS().getClientCredentialsAccessToken(tppResource.tpp)
 
         val patchedConsent = PaymentRS().getConsent<OBWriteInternationalScheduledConsentResponse2>(
             PaymentFactory.urlWithConsentId(


### PR DESCRIPTION
There was a bug in the payment consent related tests, which was causing a JWS with payload to be sent in the x-jws-signature header, when a detached JWS is required.

Refactored the code relating to creating detached JWS signatures and interacting with the Payment API. New PaymentApiClient should be used instead of the existing PaymentRS (which has been deprecated). Migrated payment tests to use the PaymentApiClient (except for tests in legacy packages)

Additional cleanup related to getting access tokens has been made by shifting the logic shared by the AccountRS and PaymentRS into the Tpp class, so that there is one set of logic for getting client_credential based AccessTokens

Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/494