### PR TITLE
505: Add tests for Rejected and Consumed status intents

### DIFF
--- a/src/test/kotlin/com/forgerock/uk/openbanking/framework/errors/Errors.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/framework/errors/Errors.kt
@@ -11,4 +11,7 @@ const val INVALID_CONSENT_STATUS = "UK.OBIE.Resource.InvalidConsentStatus"
 const val INVALID_DETACHED_JWS_ERROR = "Could not validate detached JWS -"
 const val INVALID_FREQUENCY_VALUE = "Invalid frequency value in the request payload."
 const val REQUEST_EXECUTION_TIME_IN_THE_PAST = "Invalid RequestedExecutionDateTime value in the request payload."
+const val LOCATION_HEADER_ERROR = "Location header contains an error"
+const val LOCATION_HEADER_NOT_EXISTS = "Location header doesn't exist"
+const val CONSENT_NOT_AUTHORISED = "Resource Owner did not authorize the request"
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
@@ -23,11 +23,7 @@ import com.forgerock.uk.openbanking.support.payment.PaymentFactory
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.api.v3_1_8.CreateDomesticPaymentsConsents
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.OBWriteDataDomestic2
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticResponse5
+import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory
 
 class CreateDomesticPayment(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_8/CreateDomesticPaymentConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_8/CreateDomesticPaymentConsentsTest.kt
@@ -75,4 +75,16 @@ class CreateDomesticPaymentConsentsTest(val tppResource: CreateTppCallback.TppRe
     fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidKidDetachedJws_v3_1_8() {
         createDomesticPaymentsConsentsApi.shouldCreateDomesticPaymentsConsents_throwsSendInvalidKidDetachedJwsTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsRejectedConsent_v3_1_8() {
+        createDomesticPaymentsConsentsApi.shouldCreateDomesticPaymentsConsents_throwsRejectedConsent_Test()
+    }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_8/GetDomesticPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_8/GetDomesticPaymentsConsentFundsConfirmationTest.kt
@@ -54,4 +54,16 @@ class GetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: CreateTpp
     fun shouldGetDomesticPaymentConsentsFundsConfirmation_true_v3_1_8() {
         getDomesticPaymentsConsentFundsConfirmationApi.shouldGetDomesticPaymentConsentsFundsConfirmation_true()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["domestic-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetDomesticPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_v3_1_8() {
+        getDomesticPaymentsConsentFundsConfirmationApi.shouldGetDomesticPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_Test()
+    }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_9/CreateDomesticPaymentConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_9/CreateDomesticPaymentConsentsTest.kt
@@ -70,4 +70,15 @@ class CreateDomesticPaymentConsentsTest(val tppResource: CreateTppCallback.TppRe
     fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidKidDetachedJws_v3_1_9() {
         createDomesticPaymentsConsentsApi.shouldCreateDomesticPaymentsConsents_throwsSendInvalidKidDetachedJwsTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsRejectedConsent_v3_1_9() {
+        createDomesticPaymentsConsentsApi.shouldCreateDomesticPaymentsConsents_throwsRejectedConsent_Test()
+    }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_9/GetDomesticPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_9/GetDomesticPaymentsConsentFundsConfirmationTest.kt
@@ -51,4 +51,15 @@ class GetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: CreateTpp
     fun shouldGetDomesticPaymentConsentsFundsConfirmation_true_v3_1_9() {
         getDomesticPaymentsConsentFundsConfirmationApi.shouldGetDomesticPaymentConsentsFundsConfirmation_true()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["domestic-payment-consents"]
+    )
+    @Test
+    fun shouldGetDomesticPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_v3_1_8() {
+        getDomesticPaymentsConsentFundsConfirmationApi.shouldGetDomesticPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_Test()
+    }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/junit/v3_1_8/CreateDomesticScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/junit/v3_1_8/CreateDomesticScheduledPaymentsConsentsTest.kt
@@ -88,4 +88,16 @@ class CreateDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCall
     fun shouldCreateDomesticScheduledPaymentsConsents_throwsRequestExecutionTimeInThePast_v3_1_8() {
         createDomesticScheduledPaymentsConsentsApi.shouldCreateDomesticScheduledPaymentsConsents_throwsRequestExecutionTimeInThePastTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPaymentsConsents_throwsRejectedConsent_v3_1_8() {
+        createDomesticScheduledPaymentsConsentsApi.shouldCreateDomesticScheduledPaymentsConsents_throwsRejectedConsentTest()
+    }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/junit/v3_1_9/CreateDomesticScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/junit/v3_1_9/CreateDomesticScheduledPaymentsConsentsTest.kt
@@ -82,4 +82,15 @@ class CreateDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCall
     fun shouldCreateDomesticScheduledPaymentsConsents_throwsRequestExecutionTimeInThePast_v3_1_9() {
         createDomesticScheduledPaymentsConsentsApi.shouldCreateDomesticScheduledPaymentsConsents_throwsRequestExecutionTimeInThePastTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPaymentsConsents_throwsRejectedConsent_v3_1_9() {
+        createDomesticScheduledPaymentsConsentsApi.shouldCreateDomesticScheduledPaymentsConsents_throwsRejectedConsentTest()
+    }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/junit/v3_1_8/CreateDomesticStandingOrderConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/junit/v3_1_8/CreateDomesticStandingOrderConsentsTest.kt
@@ -99,4 +99,16 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
     fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidKidDetachedJws_v3_1_8() {
         createDomesticStandingOrderConsents.shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidKidDetachedJwsTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsRejectedConsent_v3_1_8() {
+        createDomesticStandingOrderConsents.shouldCreateDomesticStandingOrdersConsents_throwsRejectedConsentTest()
+    }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/junit/v3_1_9/CreateDomesticStandingOrderConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/junit/v3_1_9/CreateDomesticStandingOrderConsentsTest.kt
@@ -92,4 +92,15 @@ class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback
     fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidKidDetachedJws_v3_1_9() {
         createDomesticStandingOrderConsents.shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidKidDetachedJwsTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsRejectedConsent_v3_1_9() {
+        createDomesticStandingOrderConsents.shouldCreateDomesticStandingOrdersConsents_throwsRejectedConsentTest()
+    }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/api/v3_1_8/CreateInternationalPayment.kt
@@ -11,10 +11,7 @@ import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.http.fuel.defaultMapper
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.framework.constants.INVALID_CONSENT_ID
-import com.forgerock.uk.openbanking.framework.errors.INVALID_FORMAT_DETACHED_JWS_ERROR
-import com.forgerock.uk.openbanking.framework.errors.NO_DETACHED_JWS
-import com.forgerock.uk.openbanking.framework.errors.PAYMENT_SUBMISSION_ALREADY_EXISTS
-import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
+import com.forgerock.uk.openbanking.framework.errors.*
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.BadJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.DefaultJwsSignatureProducer

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/CreateInternationalPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/CreateInternationalPaymentsConsents.kt
@@ -10,9 +10,7 @@ import com.forgerock.securebanking.framework.configuration.psu
 import com.forgerock.securebanking.framework.data.AccessToken
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
-import com.forgerock.uk.openbanking.framework.errors.INVALID_FORMAT_DETACHED_JWS_ERROR
-import com.forgerock.uk.openbanking.framework.errors.NO_DETACHED_JWS
-import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
+import com.forgerock.uk.openbanking.framework.errors.*
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.BadJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.DefaultJwsSignatureProducer
@@ -21,10 +19,7 @@ import com.forgerock.uk.openbanking.support.payment.PaymentAS
 import com.forgerock.uk.openbanking.support.payment.defaultPaymentScopesForAccessToken
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse6
+import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory
 
 class CreateInternationalPaymentsConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
@@ -113,6 +108,22 @@ class CreateInternationalPaymentsConsents(val version: OBVersion, val tppResourc
         // Then
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
         assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+    }
+
+    fun shouldCreateInternationalPaymentConsents_throwsRejectedConsent_Test() {
+        // Given
+        val consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()
+
+        // When
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            createInternationalPaymentConsentAndReject(
+                consentRequest
+            )
+        }
+
+        // Then
+        assertThat(exception.message.toString()).contains(CONSENT_NOT_AUTHORISED)
+
     }
 
     fun createInternationalPaymentConsent(consentRequest: OBWriteInternationalConsent5): OBWriteInternationalConsentResponse6 {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsentFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsentFundsConfirmation.kt
@@ -155,7 +155,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
     fun shouldGetInternationalPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_Test() {
         // Given
         val consentRequest = aValidOBWriteInternationalConsent5()
-        val (consent, accessTokenAuthorizationCode) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndReject(
+        val (consent, accessTokenAuthorizationCode) = createInternationalPaymentsConsents.createInternationalPaymentConsentAndAuthorize(
             consentRequest
         )
         val patchedConsent = createInternationalPaymentsConsents.getPatchedConsent(consent)

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_8/CreateInternationalPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_8/CreateInternationalPaymentsConsentsTest.kt
@@ -87,4 +87,16 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
     fun shouldCreateInternationalPaymentConsents_throwsSendInvalidKidDetachedJws_v3_1_8() {
         createInternationalPaymentsConsents.shouldCreateInternationalPaymentConsents_throwsSendInvalidKidDetachedJwsTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateInternationalPaymentConsent"],
+        apis = ["international-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalPaymentConsents_throwsRejectedConsent_v3_1_8() {
+        createInternationalPaymentsConsents.shouldCreateInternationalPaymentConsents_throwsRejectedConsent_Test()
+    }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_8/GetInternationalPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_8/GetInternationalPaymentsConsentFundsConfirmationTest.kt
@@ -104,7 +104,6 @@ class GetInternationalPaymentsConsentFundsConfirmationTest(val tppResource: Crea
         getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_throwsWrongGrantType_Test()
     }
 
-    @Disabled("The consent status is not changed to Consumed after the payment is submitted. This functionality should be implemented.")
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.8",

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_9/CreateInternationalPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_9/CreateInternationalPaymentsConsentsTest.kt
@@ -81,4 +81,15 @@ class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback
     fun shouldCreateInternationalPaymentConsents_throwsSendInvalidKidDetachedJws_v3_1_9() {
         createInternationalPaymentsConsents.shouldCreateInternationalPaymentConsents_throwsSendInvalidKidDetachedJwsTest()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalPaymentConsent"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalPaymentConsents_throwsRejectedConsent_v3_1_9() {
+        createInternationalPaymentsConsents.shouldCreateInternationalPaymentConsents_throwsRejectedConsent_Test()
+    }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_9/GetInternationalPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_9/GetInternationalPaymentsConsentFundsConfirmationTest.kt
@@ -97,7 +97,7 @@ class GetInternationalPaymentsConsentFundsConfirmationTest(val tppResource: Crea
         getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_throwsWrongGrantType_Test()
     }
 
-    @Disabled("The consent status is not changed to Consumed after the payment is submitted. This functionality should be implemented.")
+    
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.9",

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/legacy/LegacyGetInternationalPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/legacy/LegacyGetInternationalPaymentsConsentFundsConfirmationTest.kt
@@ -437,7 +437,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
     }
 
-    @Disabled("The consent status is not changed to Consumed after the payment is submitted. This functionality should be implemented.")
+    
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.4",
@@ -938,7 +938,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
     }
 
-    @Disabled("The consent status is not changed to Consumed after the payment is submitted. This functionality should be implemented.")
+    
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.3",
@@ -1441,7 +1441,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
     }
 
-    @Disabled("The consent status is not changed to Consumed after the payment is submitted. This functionality should be implemented.")
+    
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.2",
@@ -1950,7 +1950,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
     }
 
-    @Disabled("The consent status is not changed to Consumed after the payment is submitted. This functionality should be implemented.")
+    
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.1",

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/api/v3_1_8/CreateInternationalScheduledPayment.kt
@@ -11,10 +11,7 @@ import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.framework.http.fuel.defaultMapper
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import com.forgerock.uk.openbanking.framework.constants.INVALID_CONSENT_ID
-import com.forgerock.uk.openbanking.framework.errors.INVALID_FORMAT_DETACHED_JWS_ERROR
-import com.forgerock.uk.openbanking.framework.errors.NO_DETACHED_JWS
-import com.forgerock.uk.openbanking.framework.errors.PAYMENT_SUBMISSION_ALREADY_EXISTS
-import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
+import com.forgerock.uk.openbanking.framework.errors.*
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.BadJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.DefaultJwsSignatureProducer
@@ -23,12 +20,7 @@ import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.map
 import com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.consents.api.v3_1_8.CreateInternationalScheduledPaymentsConsents
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3Data
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse6
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledResponse5
+import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5MandatoryFields
 
@@ -365,6 +357,6 @@ class CreateInternationalScheduledPayment(val version: OBVersion, val tppResourc
                         patchedConsent.data.initiation
                     )
                 )
-            )
+        )
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/CreateInternationalScheduledPaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/CreateInternationalScheduledPaymentsConsents.kt
@@ -10,10 +10,7 @@ import com.forgerock.securebanking.framework.configuration.psu
 import com.forgerock.securebanking.framework.data.AccessToken
 import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
-import com.forgerock.uk.openbanking.framework.errors.INVALID_FORMAT_DETACHED_JWS_ERROR
-import com.forgerock.uk.openbanking.framework.errors.NO_DETACHED_JWS
-import com.forgerock.uk.openbanking.framework.errors.REQUEST_EXECUTION_TIME_IN_THE_PAST
-import com.forgerock.uk.openbanking.framework.errors.UNAUTHORIZED
+import com.forgerock.uk.openbanking.framework.errors.*
 import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.BadJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.DefaultJwsSignatureProducer
@@ -137,6 +134,22 @@ class CreateInternationalScheduledPaymentsConsents(
         assertThat(exception.message.toString()).contains(REQUEST_EXECUTION_TIME_IN_THE_PAST)
     }
 
+    fun shouldCreateInternationalScheduledPaymentConsents_throwsRejectedConsent_Test() {
+        // Given
+        val consentRequest =
+            OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent5()
+
+        // When
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            createInternationalScheduledPaymentConsentAndReject(
+                consentRequest
+            )
+        }
+
+        // Then
+        assertThat(exception.message.toString()).contains(CONSENT_NOT_AUTHORISED)
+    }
+
     fun createInternationalScheduledPaymentConsent(consentRequest: OBWriteInternationalScheduledConsent5): OBWriteInternationalScheduledConsentResponse6 {
         return buildCreateConsentRequest(consentRequest).sendRequest()
     }
@@ -168,7 +181,8 @@ class CreateInternationalScheduledPaymentsConsents(
             consent.data.consentId,
             tppResource.tpp.registrationResponse,
             psu,
-            tppResource.tpp
+            tppResource.tpp,
+            "Rejected"
         )
 
         return consent to accessTokenAuthorizationCode

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_8/CreateInternationalScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_8/CreateInternationalScheduledPaymentsConsentsTest.kt
@@ -100,4 +100,16 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
     fun shouldCreateInternationalScheduledPaymentConsents_throwsRequestExecutionTimeInThePast_v3_1_8() {
         createInternationalScheduledPaymentsConsents.shouldCreateInternationalScheduledPaymentConsents_throwsRequestExecutionTimeInThePast_Test()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPaymentConsents_throwsRejectedConsent_v3_1_8() {
+        createInternationalScheduledPaymentsConsents.shouldCreateInternationalScheduledPaymentConsents_throwsRejectedConsent_Test()
+    }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_8/GetInternationalScheduledPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_8/GetInternationalScheduledPaymentsConsentFundsConfirmationTest.kt
@@ -104,7 +104,6 @@ class GetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tppResou
         getInternationalScheduledPaymentsConsentFundsConfirmation.shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_throwsWrongGrantType_Test()
     }
 
-    @Disabled("The consent status is not changed to Consumed after the payment is submitted. This functionality should be implemented.")
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.8",

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_9/CreateInternationalScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_9/CreateInternationalScheduledPaymentsConsentsTest.kt
@@ -93,4 +93,15 @@ class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTp
     fun shouldCreateInternationalScheduledPaymentConsents_throwsRequestExecutionTimeInThePast_v3_1_9() {
         createInternationalScheduledPaymentsConsents.shouldCreateInternationalScheduledPaymentConsents_throwsRequestExecutionTimeInThePast_Test()
     }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPaymentConsents_throwsRejectedConsent_v3_1_9() {
+        createInternationalScheduledPaymentsConsents.shouldCreateInternationalScheduledPaymentConsents_throwsRejectedConsent_Test()
+    }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_9/GetInternationalScheduledPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_9/GetInternationalScheduledPaymentsConsentFundsConfirmationTest.kt
@@ -97,7 +97,6 @@ class GetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tppResou
         getInternationalScheduledPaymentsConsentFundsConfirmation.shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_throwsWrongGrantType_Test()
     }
 
-    @Disabled("The consent status is not changed to Consumed after the payment is submitted. This functionality should be implemented.")
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.9",

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/legacy/LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/legacy/LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest.kt
@@ -437,7 +437,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
     }
 
-    @Disabled("The consent status is not changed to Consumed after the payment is submitted. This functionality should be implemented.")
+    
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.4",
@@ -938,7 +938,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
     }
 
-    @Disabled("The consent status is not changed to Consumed after the payment is submitted. This functionality should be implemented.")
+    
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.3",
@@ -1441,7 +1441,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
     }
 
-    @Disabled("The consent status is not changed to Consumed after the payment is submitted. This functionality should be implemented.")
+    
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.2",
@@ -1950,7 +1950,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
     }
 
-    @Disabled("The consent status is not changed to Consumed after the payment is submitted. This functionality should be implemented.")
+    
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.1",


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/505

Added functional tests for:
- Rejected consents in every type of payment
- Invalid status when making a funds confirmation request with an intent with the Consumed status.
        From the [OB documentation](https://openbankinguk.github.io/read-write-api-site3/v3.1.8/resources-and-data-models/pisp/international-payment-consents.html#get-international-payment-consents-consentid-funds-confirmation):
        An ASPSP can only respond to a funds confirmation request if the payment consent (international payment, international scheduled payment) resource has an Authorised status. If the status is not Authorised, an ASPSP must respond with a 400 (Bad Request) and a UK.OBIE.Resource.InvalidConsentStatus error code.
