### PR TITLE
424: OBIE 3.1.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("javax.xml.bind:jaxb-api:2.3.1")
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
-    implementation(platform("com.forgerock.securebanking.uk:securebanking-openbanking-uk-bom:1.1.6-SNAPSHOT"))
+    implementation(platform("com.forgerock.securebanking.uk:securebanking-openbanking-uk-bom:1.1.7-SNAPSHOT"))
     implementation("com.forgerock.securebanking.uk:securebanking-openbanking-uk-common")
     implementation("com.forgerock.securebanking.uk:securebanking-openbanking-uk-obie-datamodel")
     implementation("com.forgerock.securebanking.uk:securebanking-openbanking-uk-forgerock-datamodel")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("javax.xml.bind:jaxb-api:2.3.1")
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
-    implementation(platform("com.forgerock.securebanking.uk:securebanking-openbanking-uk-bom:1.1.4-SNAPSHOT"))
+    implementation(platform("com.forgerock.securebanking.uk:securebanking-openbanking-uk-bom:1.1.6-SNAPSHOT"))
     implementation("com.forgerock.securebanking.uk:securebanking-openbanking-uk-common")
     implementation("com.forgerock.securebanking.uk:securebanking-openbanking-uk-obie-datamodel")
     implementation("com.forgerock.securebanking.uk:securebanking-openbanking-uk-forgerock-datamodel")
@@ -230,7 +230,7 @@ tasks.withType<Test>().configureEach {
 // tests properties
 val packagePrefix = "com.forgerock.uk.openbanking.tests.functional."
 val suffixPattern = ".*"
-val apiVersions = arrayOf("v3_1_8", "v3_1_9")
+val apiVersions = arrayOf("v3_1_8", "v3_1_9", "v3_1_10")
 
 // Add test tasks for each supported apiVersion
 for (apiVersion in apiVersions) {

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentApiClient.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentApiClient.kt
@@ -72,7 +72,8 @@ class PaymentApiClient(val tpp: Tpp) {
 
             if (!response.isSuccessful) {
                 throw AssertionError(
-                    "Could not create the consent: \n" + result.component2()?.errorData?.toString(Charsets.UTF_8),
+                    "API call: " +request.method + " "+ request.url + " returned an error response:\n"
+                            + result.component2()?.errorData?.toString(Charsets.UTF_8),
                     result.component2()
                 )
             }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentFactory.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentFactory.kt
@@ -50,51 +50,51 @@ class PaymentFactory {
             }
         }
 
-        fun mapOBWriteDomestic2DataInitiationToOBDomestic2(initiation: OBWriteDomestic2DataInitiation): OBDomestic2 {
-            val domesticPayment = OBDomestic2()
-                .instructionIdentification(initiation.instructionIdentification)
-                .endToEndIdentification(initiation.endToEndIdentification)
-                .localInstrument(initiation.localInstrument)
-                .creditorPostalAddress(initiation.creditorPostalAddress)
-                .supplementaryData(initiation.supplementaryData)
+        fun mapOBDomestic2ToOBWriteDomestic2DataInitiation(obDomestic2: OBDomestic2): OBWriteDomestic2DataInitiation {
+            val initiation = OBWriteDomestic2DataInitiation()
+                    .instructionIdentification(obDomestic2.instructionIdentification)
+                    .endToEndIdentification(obDomestic2.endToEndIdentification)
+                    .localInstrument(obDomestic2.localInstrument)
+                    .creditorPostalAddress(obDomestic2.creditorPostalAddress)
+                    .supplementaryData(obDomestic2.supplementaryData)
 
-            if (initiation.instructedAmount != null) {
-                domesticPayment.instructedAmount(
-                    OBActiveOrHistoricCurrencyAndAmount()
-                        .amount(initiation.instructedAmount?.amount)
-                        .currency(initiation.instructedAmount?.currency)
+            if (obDomestic2.instructedAmount != null) {
+                initiation.instructedAmount(
+                        OBWriteDomestic2DataInitiationInstructedAmount()
+                                .amount(obDomestic2.instructedAmount?.amount)
+                                .currency(obDomestic2.instructedAmount?.currency)
                 )
             }
 
-            if (initiation.debtorAccount != null) {
-                domesticPayment.debtorAccount(
-                    OBCashAccount3()
-                        .schemeName(initiation.debtorAccount?.schemeName)
-                        .identification(initiation.debtorAccount?.identification)
-                        .name(initiation.debtorAccount?.name)
-                        .secondaryIdentification(initiation.debtorAccount?.secondaryIdentification)
+            if (obDomestic2.debtorAccount != null) {
+                initiation.debtorAccount(
+                        OBWriteDomestic2DataInitiationDebtorAccount()
+                                .schemeName(obDomestic2.debtorAccount?.schemeName)
+                                .identification(obDomestic2.debtorAccount?.identification)
+                                .name(obDomestic2.debtorAccount?.name)
+                                .secondaryIdentification(obDomestic2.debtorAccount?.secondaryIdentification)
                 )
             }
 
-            if (initiation.creditorAccount != null) {
-                domesticPayment.creditorAccount(
-                    OBCashAccount3()
-                        .schemeName(initiation.creditorAccount?.schemeName)
-                        .identification(initiation.creditorAccount?.identification)
-                        .name(initiation.creditorAccount?.name)
-                        .secondaryIdentification(initiation.creditorAccount?.secondaryIdentification)
+            if (obDomestic2.creditorAccount != null) {
+                initiation.creditorAccount(
+                        OBWriteDomestic2DataInitiationCreditorAccount()
+                                .schemeName(obDomestic2.creditorAccount?.schemeName)
+                                .identification(obDomestic2.creditorAccount?.identification)
+                                .name(obDomestic2.creditorAccount?.name)
+                                .secondaryIdentification(obDomestic2.creditorAccount?.secondaryIdentification)
                 )
             }
 
-            if (initiation.remittanceInformation != null) {
-                domesticPayment.remittanceInformation(
-                    OBRemittanceInformation1()
-                        .unstructured(initiation.remittanceInformation?.unstructured)
-                        .reference(initiation.remittanceInformation?.reference)
+            if (obDomestic2.remittanceInformation != null) {
+                initiation.remittanceInformation(
+                        OBWriteDomestic2DataInitiationRemittanceInformation()
+                                .unstructured(obDomestic2.remittanceInformation?.unstructured)
+                                .reference(obDomestic2.remittanceInformation?.reference)
                 )
             }
 
-            return domesticPayment
+            return initiation
         }
 
         fun mapOBDomesticScheduled2ToOBWriteDomesticScheduled2DataInitiation(initiation: OBDomesticScheduled2): OBWriteDomesticScheduled2DataInitiation? {
@@ -202,6 +202,29 @@ class PaymentFactory {
             return standingOrder
         }
 
+        fun copyOBWriteDomestic2DataInitiation(initiation: OBWriteDomestic2DataInitiation): OBWriteDomestic2DataInitiation {
+            val result = OBWriteDomestic2DataInitiation()
+                    .instructionIdentification(initiation.instructionIdentification)
+                    .endToEndIdentification(initiation.endToEndIdentification)
+                    .localInstrument(initiation.localInstrument)
+                    .debtorAccount(initiation.debtorAccount)
+                    .creditorAccount(initiation.creditorAccount)
+                    .creditorPostalAddress(initiation.creditorPostalAddress)
+                    .remittanceInformation(initiation.remittanceInformation)
+                    .supplementaryData(initiation.supplementaryData)
+
+            if (initiation.instructedAmount != null) {
+                result.instructedAmount(
+                        OBWriteDomestic2DataInitiationInstructedAmount()
+                                .amount(initiation.instructedAmount.amount)
+                                .currency(initiation.instructedAmount.currency)
+                )
+            }
+
+            return result
+
+        }
+
         fun copyOBWriteDomesticScheduled2DataInitiation(initiation: OBWriteDomesticScheduled2DataInitiation): OBWriteDomesticScheduled2DataInitiation {
             val domesticScheduledPayment = OBWriteDomesticScheduled2DataInitiation()
                 .instructionIdentification(initiation.instructionIdentification)
@@ -223,45 +246,6 @@ class PaymentFactory {
             }
 
             return domesticScheduledPayment
-        }
-
-        fun copyOBWriteDomesticStandingOrder3DataInitiation(initiation: OBWriteDomesticStandingOrder3DataInitiation): OBWriteDomesticStandingOrder3DataInitiation {
-            val standingOrder = OBWriteDomesticStandingOrder3DataInitiation()
-                .frequency(initiation.frequency)
-                .reference(initiation.reference)
-                .numberOfPayments(initiation.numberOfPayments)
-                .debtorAccount(initiation.debtorAccount)
-                .creditorAccount(initiation.creditorAccount)
-                .firstPaymentDateTime(initiation.firstPaymentDateTime)
-                .recurringPaymentDateTime(initiation.recurringPaymentDateTime)
-                .finalPaymentDateTime(initiation.finalPaymentDateTime)
-                .supplementaryData(initiation.supplementaryData)
-
-            if (initiation.firstPaymentAmount != null) {
-                standingOrder.firstPaymentAmount(
-                    OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount()
-                        .amount(initiation.firstPaymentAmount.amount)
-                        .currency(initiation.firstPaymentAmount.currency)
-                )
-            }
-
-            if (initiation.recurringPaymentAmount != null) {
-                standingOrder.recurringPaymentAmount(
-                    OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount()
-                        .amount(initiation.recurringPaymentAmount.amount)
-                        .currency(initiation.recurringPaymentAmount.currency)
-                )
-            }
-
-            if (initiation.finalPaymentAmount != null) {
-                standingOrder.finalPaymentAmount(
-                    OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount()
-                        .amount(initiation.finalPaymentAmount.amount)
-                        .currency(initiation.finalPaymentAmount.currency)
-                )
-            }
-
-            return standingOrder
         }
 
         fun mapOBWriteInternational2DataInitiationToOBInternational2(initiation: OBWriteInternational2DataInitiation): OBInternational2 {
@@ -528,6 +512,62 @@ class PaymentFactory {
             }
 
             return internationalScheduledPayment
+        }
+
+        fun mapOBWriteDomesticStandingOrderConsentResponse6DataInitiationToOBWriteDomesticStandingOrder3DataInitiation(inputInitiation: OBWriteDomesticStandingOrderConsentResponse6DataInitiation): OBWriteDomesticStandingOrder3DataInitiation {
+            val outputInitiation = OBWriteDomesticStandingOrder3DataInitiation()
+                    .frequency(inputInitiation.frequency)
+                    .reference(inputInitiation.reference)
+                    .numberOfPayments(inputInitiation.numberOfPayments)
+                    .firstPaymentDateTime(inputInitiation.firstPaymentDateTime)
+                    .recurringPaymentDateTime(inputInitiation.recurringPaymentDateTime)
+                    .finalPaymentDateTime(inputInitiation.finalPaymentDateTime)
+                    .supplementaryData(inputInitiation.supplementaryData)
+
+            if (inputInitiation.firstPaymentAmount != null) {
+                outputInitiation.firstPaymentAmount(
+                        OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount()
+                                .amount(inputInitiation.firstPaymentAmount?.amount)
+                                .currency(inputInitiation.firstPaymentAmount?.currency)
+                )
+            }
+
+            if (inputInitiation.recurringPaymentAmount != null) {
+                outputInitiation.recurringPaymentAmount(
+                        OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount()
+                                .amount(inputInitiation.recurringPaymentAmount?.amount)
+                                .currency(inputInitiation.recurringPaymentAmount?.currency)
+                )
+            }
+
+            if (inputInitiation.finalPaymentAmount != null) {
+                outputInitiation.finalPaymentAmount(
+                        OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount()
+                                .amount(inputInitiation.finalPaymentAmount?.amount)
+                                .currency(inputInitiation.finalPaymentAmount?.currency)
+                )
+            }
+
+            if (inputInitiation.debtorAccount != null) {
+                outputInitiation.debtorAccount(
+                        OBWriteDomesticStandingOrder3DataInitiationDebtorAccount()
+                                .schemeName(inputInitiation.debtorAccount?.schemeName)
+                                .identification(inputInitiation.debtorAccount?.identification)
+                                .name(inputInitiation.debtorAccount?.name)
+                                .secondaryIdentification(inputInitiation.debtorAccount?.secondaryIdentification)
+                )
+            }
+
+            if (inputInitiation.creditorAccount != null) {
+                outputInitiation.creditorAccount(
+                        OBWriteDomesticStandingOrder3DataInitiationCreditorAccount()
+                                .schemeName(inputInitiation.creditorAccount?.schemeName)
+                                .identification(inputInitiation.creditorAccount?.identification)
+                                .name(inputInitiation.creditorAccount?.name)
+                                .secondaryIdentification(inputInitiation.creditorAccount?.secondaryIdentification)
+                )
+            }
+            return outputInitiation
         }
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/access/consents/junit/v3_1_10/AccountAccessConsentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/access/consents/junit/v3_1_10/AccountAccessConsentTest.kt
@@ -1,0 +1,48 @@
+package com.forgerock.uk.openbanking.tests.functional.account.access.consents.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.access.consents.api.v3_1_8.AccountAccessConsent
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AccountAccessConsentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var accountAccessConsentApi: AccountAccessConsent
+
+    @BeforeEach
+    fun setUp() {
+        accountAccessConsentApi = AccountAccessConsent(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent"]
+    )
+    @Test
+    fun createAccountAccessConsents_v3_1_10() {
+        accountAccessConsentApi.createAccountAccessConsentTest()
+    }
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["DeleteAccountAccessConsent"]
+    )
+    @Test
+    fun deleteAccountAccessConsents_v3_1_10() {
+        accountAccessConsentApi.deleteAccountAccessConsentTest()
+    }
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["GetAccountAccessConsent"]
+    )
+    @Test
+    fun getAccountAccessConsents_v3_1_10() {
+        accountAccessConsentApi.getAccountAccessConsentTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/accounts/junit/v3_1_10/GetAccountTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/accounts/junit/v3_1_10/GetAccountTest.kt
@@ -1,0 +1,22 @@
+package com.forgerock.uk.openbanking.tests.functional.account.accounts.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.accounts.api.v3_1_8.GetAccount
+import org.junit.jupiter.api.Test
+
+
+class GetAccountTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccount"],
+        apis = ["accounts"]
+    )
+    @Test
+    fun shouldGetAccount_v3_1_10() {
+        GetAccount(OBVersion.v3_1_10, tppResource).shouldGetAccountTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/accounts/junit/v3_1_10/GetAccountsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/accounts/junit/v3_1_10/GetAccountsTest.kt
@@ -1,0 +1,22 @@
+package com.forgerock.uk.openbanking.tests.functional.account.accounts.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.accounts.api.v3_1_8.GetAccounts
+import org.junit.jupiter.api.Test
+
+
+class GetAccountsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts"],
+        apis = ["accounts"]
+    )
+    @Test
+    fun shouldGetAccounts_v3_1_10() {
+        GetAccounts(OBVersion.v3_1_10, tppResource).shouldGetAccountsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/balances/junit/v3_1_10/GetAccountBalancesTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/balances/junit/v3_1_10/GetAccountBalancesTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.balances.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.balances.api.v3_1_8.GetAccountBalances
+import org.junit.jupiter.api.Test
+
+class GetAccountBalancesTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountBalances"],
+        apis = ["balances"]
+    )
+    @Test
+    fun shouldGetAccountBalances_v3_1_10() {
+        GetAccountBalances(OBVersion.v3_1_10, tppResource).shouldGetAccountBalancesTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/balances/junit/v3_1_10/GetBalancesTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/balances/junit/v3_1_10/GetBalancesTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.balances.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.balances.api.v3_1_8.GetBalances
+import org.junit.jupiter.api.Test
+
+class GetBalancesTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetBalances"],
+        apis = ["balances"]
+    )
+    @Test
+    fun shouldGetBalances_v3_1_10() {
+        GetBalances(OBVersion.v3_1_10, tppResource).shouldGetBalancesTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/beneficiaries/junit/v3_1_10/GetAccountBeneficiariesTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/beneficiaries/junit/v3_1_10/GetAccountBeneficiariesTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.beneficiaries.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.beneficiaries.api.v3_1_8.GetAccountBeneficiaries
+import org.junit.jupiter.api.Test
+
+class GetAccountBeneficiariesTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountBeneficiaries"],
+        apis = ["beneficiaries"]
+    )
+    @Test
+    fun shouldGetAccountBeneficiaries_v3_1_10() {
+        GetAccountBeneficiaries(OBVersion.v3_1_10, tppResource).shouldGetAccountBeneficiariesTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/beneficiaries/junit/v3_1_10/GetBeneficiariesTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/beneficiaries/junit/v3_1_10/GetBeneficiariesTest.kt
@@ -1,0 +1,20 @@
+package com.forgerock.uk.openbanking.tests.functional.account.beneficiaries.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.beneficiaries.api.v3_1_8.GetBeneficiaries
+import org.junit.jupiter.api.Test
+
+class GetBeneficiariesTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetBeneficiaries"],
+        apis = ["beneficiaries"]
+    )
+    @Test
+    fun shouldGetBeneficiaries_v3_1_10() {
+        GetBeneficiaries(OBVersion.v3_1_10, tppResource).shouldGetBeneficiariesTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/direct/debits/junit/v3_1_10/GetAccountDirectDebitsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/direct/debits/junit/v3_1_10/GetAccountDirectDebitsTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.direct.debits.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.direct.debits.api.v3_1_8.GetAccountDirectDebits
+import org.junit.jupiter.api.Test
+
+class GetAccountDirectDebitsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccountDirectDebits"],
+        apis = ["direct-debits"]
+    )
+    @Test
+    fun shouldGetAccountDirectDebits_v3_1_10() {
+        GetAccountDirectDebits(OBVersion.v3_1_10, tppResource).shouldGetAccountDirectDebitsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/direct/debits/junit/v3_1_10/GetDirectDebitsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/direct/debits/junit/v3_1_10/GetDirectDebitsTest.kt
@@ -1,0 +1,20 @@
+package com.forgerock.uk.openbanking.tests.functional.account.direct.debits.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.direct.debits.api.v3_1_8.GetDirectDebits
+import org.junit.jupiter.api.Test
+
+class GetDirectDebitsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetDirectDebits"],
+        apis = ["direct-debits"]
+    )
+    @Test
+    fun shouldGetDirectDebits_v3_1_10() {
+        GetDirectDebits(OBVersion.v3_1_10, tppResource).shouldGetDirectDebitsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/offers/junit/v3_1_10/GetAccountOffersTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/offers/junit/v3_1_10/GetAccountOffersTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.offers.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.offers.api.v3_1_8.GetAccountOffers
+import org.junit.jupiter.api.Test
+
+class GetAccountOffersTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountOffers"],
+        apis = ["offers"]
+    )
+    @Test
+    fun shouldGetAccountOffers_v3_1_10() {
+        GetAccountOffers(OBVersion.v3_1_10, tppResource).shouldGetAccountOffersTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/offers/junit/v3_1_10/GetOffersTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/offers/junit/v3_1_10/GetOffersTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.offers.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.offers.api.v3_1_8.GetOffers
+import org.junit.jupiter.api.Test
+
+class GetOffersTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetOffers"],
+        apis = ["offers"]
+    )
+    @Test
+    fun shouldGetOffers_v3_1_10() {
+        GetOffers(OBVersion.v3_1_10, tppResource).shouldGetOffersTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/parties/junit/v3_1_10/GetAccountPartiesTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/parties/junit/v3_1_10/GetAccountPartiesTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.parties.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.parties.api.v3_1_8.GetAccountParties
+import org.junit.jupiter.api.Test
+
+class GetAccountPartiesTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountParties"],
+        apis = ["party"]
+    )
+    @Test
+    fun shouldGetAccountParties_v3_1_10() {
+        GetAccountParties(OBVersion.v3_1_10, tppResource).shouldGetAccountPartiesTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/parties/junit/v3_1_10/GetAccountPartyTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/parties/junit/v3_1_10/GetAccountPartyTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.parties.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.parties.api.v3_1_8.GetAccountParty
+import org.junit.jupiter.api.Test
+
+class GetAccountPartyTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountParty"],
+        apis = ["party"]
+    )
+    @Test
+    fun shouldGetAccountParty_v3_1_10() {
+        GetAccountParty(OBVersion.v3_1_10, tppResource).shouldGetAccountPartyTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/parties/junit/v3_1_10/GetPartyTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/parties/junit/v3_1_10/GetPartyTest.kt
@@ -1,0 +1,20 @@
+package com.forgerock.uk.openbanking.tests.functional.account.parties.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.parties.api.v3_1_8.GetParty
+import org.junit.jupiter.api.Test
+
+class GetPartyTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetParty"],
+        apis = ["party"]
+    )
+    @Test
+    fun shouldGetParty_v3_1_10() {
+        GetParty(OBVersion.v3_1_10, tppResource).shouldGetPartyTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/products/junit/v3_1_10/GetAccountProductTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/products/junit/v3_1_10/GetAccountProductTest.kt
@@ -1,0 +1,21 @@
+package com.forgerock.uk.openbanking.tests.functional.account.products.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.products.api.v3_1_8.GetAccountProduct
+import org.junit.jupiter.api.Test
+
+class GetAccountProductTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountProduct"],
+        apis = ["products"]
+    )
+    @Test
+    fun shouldGetAccountProduct_v3_1_10() {
+        GetAccountProduct(OBVersion.v3_1_10, tppResource).shouldGetAccountProductTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/products/junit/v3_1_10/GetProductsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/products/junit/v3_1_10/GetProductsTest.kt
@@ -1,0 +1,20 @@
+package com.forgerock.uk.openbanking.tests.functional.account.products.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.products.api.v3_1_8.GetProducts
+import org.junit.jupiter.api.Test
+
+class GetProductsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetProducts"],
+        apis = ["products"]
+    )
+    @Test
+    fun shouldGetProducts_v3_1_10() {
+        GetProducts(OBVersion.v3_1_10, tppResource).shouldGetProductsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/scheduled/payments/junit/v3_1_10/GetAccountScheduledPaymentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/scheduled/payments/junit/v3_1_10/GetAccountScheduledPaymentsTest.kt
@@ -1,0 +1,20 @@
+package com.forgerock.uk.openbanking.tests.functional.account.scheduled.payments.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.scheduled.payments.api.v3_1_8.GetAccountScheduledPayments
+import org.junit.jupiter.api.Test
+
+class GetAccountScheduledPaymentsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountScheduledPayments"],
+        apis = ["scheduled-payments"]
+    )
+    @Test
+    fun shouldGetAccountScheduledPayments_v3_1_10() {
+        GetAccountScheduledPayments(OBVersion.v3_1_10, tppResource).shouldGetAccountScheduledPaymentsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/scheduled/payments/junit/v3_1_10/GetScheduledPaymentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/scheduled/payments/junit/v3_1_10/GetScheduledPaymentsTest.kt
@@ -1,0 +1,20 @@
+package com.forgerock.uk.openbanking.tests.functional.account.scheduled.payments.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.scheduled.payments.api.v3_1_8.GetScheduledPayments
+import org.junit.jupiter.api.Test
+
+class GetScheduledPaymentsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetScheduledPayments"],
+        apis = ["scheduled-payments"]
+    )
+    @Test
+    fun shouldGetScheduledPayments_v3_1_10() {
+        GetScheduledPayments(OBVersion.v3_1_10, tppResource).shouldGetScheduledPaymentsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/standing/orders/junit/v3_1_10/GetAccountStandingOrdersTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/standing/orders/junit/v3_1_10/GetAccountStandingOrdersTest.kt
@@ -1,0 +1,20 @@
+package com.forgerock.uk.openbanking.tests.functional.account.standing.orders.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.standing.orders.api.v3_1_8.GetAccountStandingOrders
+import org.junit.jupiter.api.Test
+
+class GetAccountStandingOrdersTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountStandingOrders"],
+        apis = ["standing-orders"]
+    )
+    @Test
+    fun shouldGetAccountStandingOrders_v3_1_10() {
+        GetAccountStandingOrders(OBVersion.v3_1_10, tppResource).shouldGetAccountStandingOrdersTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/standing/orders/junit/v3_1_10/GetStandingOrdersTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/standing/orders/junit/v3_1_10/GetStandingOrdersTest.kt
@@ -1,0 +1,20 @@
+package com.forgerock.uk.openbanking.tests.functional.account.standing.orders.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.standing.orders.api.v3_1_8.GetStandingOrders
+import org.junit.jupiter.api.Test
+
+class GetStandingOrdersTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetStandingOrders"],
+        apis = ["standing-orders"]
+    )
+    @Test
+    fun shouldGetStandingOrders_v3_1_10() {
+        GetStandingOrders(OBVersion.v3_1_10, tppResource).shouldGetStandingOrdersTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_10/GetAccountStatementFileTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_10/GetAccountStatementFileTest.kt
@@ -1,0 +1,40 @@
+package com.forgerock.uk.openbanking.tests.functional.account.statements.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.statements.api.v3_1_8.GetAccountStatementFile
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetAccountStatementFileTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getAccountStatementFileApi: GetAccountStatementFile
+
+    @BeforeEach
+    fun setUp() {
+        getAccountStatementFileApi = GetAccountStatementFile(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountStatementFile"],
+        apis = ["statements"]
+    )
+    @Test
+    fun shouldGet_badRequest_StatementFile_v3_1_10() {
+        getAccountStatementFileApi.shouldGet_badRequest_StatementFileTest()
+    }
+
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountStatementFile"],
+        apis = ["statements"]
+    )
+    @Test
+    fun shouldGetStatementFile_v3_1_10() {
+        getAccountStatementFileApi.shouldGetStatementFileTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_10/GetAccountStatementTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_10/GetAccountStatementTest.kt
@@ -1,0 +1,20 @@
+package com.forgerock.uk.openbanking.tests.functional.account.statements.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.statements.api.v3_1_8.GetAccountStatement
+import org.junit.jupiter.api.Test
+
+class GetAccountStatementTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountStatement"],
+        apis = ["statements"]
+    )
+    @Test
+    fun shouldGetAccountStatement_v3_1_10() {
+        GetAccountStatement(OBVersion.v3_1_10, tppResource).shouldGetAccountStatementTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_10/GetAccountStatementTransactionsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_10/GetAccountStatementTransactionsTest.kt
@@ -1,0 +1,20 @@
+package com.forgerock.uk.openbanking.tests.functional.account.statements.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.statements.api.v3_1_8.GetAccountStatementTransactions
+import org.junit.jupiter.api.Test
+
+class GetAccountStatementTransactionsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountStatementTransactions"],
+        apis = ["statements"]
+    )
+    @Test
+    fun shouldGetAccountStatementTransactions_v3_1_10() {
+        GetAccountStatementTransactions(OBVersion.v3_1_10, tppResource).shouldGetAccountStatementTransactionsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_10/GetAccountStatementsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_10/GetAccountStatementsTest.kt
@@ -1,0 +1,20 @@
+package com.forgerock.uk.openbanking.tests.functional.account.statements.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.statements.api.v3_1_8.GetAccountStatements
+import org.junit.jupiter.api.Test
+
+class GetAccountStatementsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountStatements"],
+        apis = ["statements"]
+    )
+    @Test
+    fun shouldGetAccountStatements_v3_1_10() {
+        GetAccountStatements(OBVersion.v3_1_10, tppResource).shouldGetAccountStatementsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_10/GetStatementsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/statements/junit/v3_1_10/GetStatementsTest.kt
@@ -1,0 +1,20 @@
+package com.forgerock.uk.openbanking.tests.functional.account.statements.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.statements.api.v3_1_8.GetStatements
+import org.junit.jupiter.api.Test
+
+class GetStatementsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetStatements"],
+        apis = ["statements"]
+    )
+    @Test
+    fun shouldGetStatements_v3_1_10() {
+        GetStatements(OBVersion.v3_1_10, tppResource).shouldGetStatementsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/transactions/junit/v3_1_10/GetAccountTransactionsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/transactions/junit/v3_1_10/GetAccountTransactionsTest.kt
@@ -1,0 +1,20 @@
+package com.forgerock.uk.openbanking.tests.functional.account.transactions.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.transactions.api.v3_1_8.GetAccountTransactions
+import org.junit.jupiter.api.Test
+
+class GetAccountTransactionsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetAccountTransactions"],
+        apis = ["transactions"]
+    )
+    @Test
+    fun shouldGetAccountTransactions_v3_1_10() {
+        GetAccountTransactions(OBVersion.v3_1_10, tppResource).shouldGetAccountTransactionsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/transactions/junit/v3_1_10/GetTransactionsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/transactions/junit/v3_1_10/GetTransactionsTest.kt
@@ -1,0 +1,20 @@
+package com.forgerock.uk.openbanking.tests.functional.account.transactions.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.account.transactions.api.v3_1_8.GetTransactions
+import org.junit.jupiter.api.Test
+
+class GetTransactionsTest(val tppResource: CreateTppCallback.TppResource) {
+    @EnabledIfVersion(
+        type = "accounts",
+        apiVersion = "v3.1.10",
+        operations = ["CreateAccountAccessConsent", "GetAccounts", "GetTransactions"],
+        apis = ["transactions"]
+    )
+    @Test
+    fun shouldGetTransactions_v3_1_10() {
+        GetTransactions(OBVersion.v3_1_10, tppResource).shouldGetTransactionsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/api/v3_1_8/CreateDomesticPayment.kt
@@ -274,9 +274,9 @@ class CreateDomesticPayment(
 
     private fun createPaymentRequest(patchedConsent: OBWriteDomesticConsentResponse5): OBWriteDomestic2 {
         return OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(PaymentFactory.mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                OBWriteDomestic2Data()
+                        .consentId(patchedConsent.data.consentId)
+                        .initiation(PaymentFactory.copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsentFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/api/v3_1_8/GetDomesticPaymentsConsentFundsConfirmation.kt
@@ -33,7 +33,7 @@ class GetDomesticPaymentsConsentFundsConfirmation(
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -96,7 +96,7 @@ class GetDomesticPaymentsConsentFundsConfirmation(
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -121,9 +121,9 @@ class GetDomesticPaymentsConsentFundsConfirmation(
 
     private fun createPaymentRequest(patchedConsent: OBWriteDomesticConsentResponse5): OBWriteDomestic2 {
         return OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(PaymentFactory.mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                OBWriteDomestic2Data()
+                        .consentId(patchedConsent.data.consentId)
+                        .initiation(PaymentFactory.copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_10/CreateDomesticPaymentConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_10/CreateDomesticPaymentConsentsTest.kt
@@ -1,0 +1,84 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.api.v3_1_8.CreateDomesticPaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateDomesticPaymentConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createDomesticPaymentsConsentsApi: CreateDomesticPaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        createDomesticPaymentsConsentsApi = CreateDomesticPaymentsConsents(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"]
+    )
+    @Test
+    fun createDomesticPaymentsConsents_v3_1_10() {
+        createDomesticPaymentsConsentsApi.createDomesticPaymentsConsentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsNoDetachedJws_v3_1_10() {
+        createDomesticPaymentsConsentsApi.shouldCreateDomesticPaymentsConsents_throwsNoDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_10() {
+        createDomesticPaymentsConsentsApi.shouldCreateDomesticPaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidFormatDetachedJws_v3_1_10() {
+        createDomesticPaymentsConsentsApi.shouldCreateDomesticPaymentsConsents_throwsSendInvalidFormatDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsSendInvalidKidDetachedJws_v3_1_10() {
+        createDomesticPaymentsConsentsApi.shouldCreateDomesticPaymentsConsents_throwsSendInvalidKidDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticPaymentsConsents_throwsRejectedConsent_v3_1_10() {
+        createDomesticPaymentsConsentsApi.shouldCreateDomesticPaymentsConsents_throwsRejectedConsent_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_10/GetDomesticPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_10/GetDomesticPaymentsConsentFundsConfirmationTest.kt
@@ -1,0 +1,65 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.api.v3_1_8.GetDomesticPaymentsConsentFundsConfirmation
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class GetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getDomesticPaymentsConsentFundsConfirmationApi: GetDomesticPaymentsConsentFundsConfirmation
+
+    @BeforeEach
+    fun setUp() {
+        getDomesticPaymentsConsentFundsConfirmationApi =
+            GetDomesticPaymentsConsentFundsConfirmation(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["domestic-payment-consents"]
+    )
+    @Test
+    fun shouldGetDomesticPaymentConsentsFundsConfirmation_false_v3_1_10() {
+        getDomesticPaymentsConsentFundsConfirmationApi.shouldGetDomesticPaymentConsentsFundsConfirmation_false()
+    }
+
+    @Disabled("Enhancement: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/337")
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["domestic-payment-consents"]
+    )
+    @Test
+    fun shouldGetDomesticPaymentConsentsFundsConfirmation_throwsWrongGrantType_v3_1_10() {
+        getDomesticPaymentsConsentFundsConfirmationApi.shouldGetDomesticPaymentConsentsFundsConfirmation_throwsWrongGrantType()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["domestic-payment-consents"]
+    )
+    @Test
+    fun shouldGetDomesticPaymentConsentsFundsConfirmation_true_v3_1_10() {
+        getDomesticPaymentsConsentFundsConfirmationApi.shouldGetDomesticPaymentConsentsFundsConfirmation_true()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["domestic-payment-consents"]
+    )
+    @Test
+    fun shouldGetDomesticPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_v3_1_8() {
+        getDomesticPaymentsConsentFundsConfirmationApi.shouldGetDomesticPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_10/GetDomesticPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_10/GetDomesticPaymentsConsentsTest.kt
@@ -1,0 +1,40 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.consents.api.v3_1_8.GetDomesticPaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetDomesticPaymentsConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getDomesticPaymentsConsentsApi: GetDomesticPaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        getDomesticPaymentsConsentsApi = GetDomesticPaymentsConsents(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"]
+    )
+    @Test
+    fun shouldGetDomesticPaymentsConsents_v3_1_10() {
+        getDomesticPaymentsConsentsApi.shouldGetDomesticPaymentsConsents()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payment-consents"]
+    )
+    @Test
+    fun shouldGetDomesticPaymentsConsents_withoutOptionalDebtorAccount_v3_1_10() {
+        getDomesticPaymentsConsentsApi.shouldGetDomesticPaymentsConsents_withoutOptionalDebtorAccountTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/legacy/LegacyGetDomesticPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/legacy/LegacyGetDomesticPaymentsConsentFundsConfirmationTest.kt
@@ -81,7 +81,7 @@ class LegacyGetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: Cre
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -138,7 +138,7 @@ class LegacyGetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: Cre
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -247,7 +247,7 @@ class LegacyGetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: Cre
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -305,7 +305,7 @@ class LegacyGetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: Cre
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -415,7 +415,7 @@ class LegacyGetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: Cre
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -473,7 +473,7 @@ class LegacyGetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: Cre
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/junit/v3_1_10/CreateDomesticPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/junit/v3_1_10/CreateDomesticPaymentTest.kt
@@ -1,0 +1,106 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.api.v3_1_8.CreateDomesticPayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createDomesticPaymentApi: CreateDomesticPayment
+
+    @BeforeEach
+    fun setUp() {
+        createDomesticPaymentApi = CreateDomesticPayment(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"]
+    )
+    @Test
+    fun createDomesticPayments_v3_1_10() {
+        createDomesticPaymentApi.createDomesticPaymentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticPayments_throwsPaymentAlreadyExists_v3_1_10() {
+        createDomesticPaymentApi.shouldCreateDomesticPayments_throwsPaymentAlreadyExistsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticPayments_throwsSendInvalidFormatDetachedJws_v3_1_10() {
+        createDomesticPaymentApi.shouldCreateDomesticPayments_throwsSendInvalidFormatDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticPayments_throwsNoDetachedJws_v3_1_10() {
+        createDomesticPaymentApi.shouldCreateDomesticPayments_throwsNoDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticPayments_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_10() {
+        createDomesticPaymentApi.shouldCreateDomesticPayments_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticPayments_throwsSendInvalidKidDetachedJws_v3_1_10() {
+        createDomesticPaymentApi.shouldCreateDomesticPayments_throwsSendInvalidKidDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_10() {
+        createDomesticPaymentApi.shouldCreateDomesticPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBodyTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_10() {
+        createDomesticPaymentApi.shouldCreateDomesticPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/junit/v3_1_10/GetDomesticPaymentDomesticPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/junit/v3_1_10/GetDomesticPaymentDomesticPaymentIdPaymentDetailsTest.kt
@@ -1,0 +1,24 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.api.v3_1_8.GetDomesticPaymentDomesticPaymentIdPaymentDetails
+import org.junit.jupiter.api.Test
+
+class GetDomesticPaymentDomesticPaymentIdPaymentDetailsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetDomesticPayment", "CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent", "GetDomesticPaymentDomesticPaymentIdPaymentDetails"],
+        apis = ["domestic-payments", "domestic-payment-consents"]
+    )
+    @Test
+    fun getDomesticPaymentDomesticPaymentIdPaymentDetails_v3_1_10() {
+        GetDomesticPaymentDomesticPaymentIdPaymentDetails(
+            OBVersion.v3_1_10,
+            tppResource
+        ).getDomesticPaymentDomesticPaymentIdPaymentDetailsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/junit/v3_1_10/GetDomesticPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/junit/v3_1_10/GetDomesticPaymentTest.kt
@@ -1,0 +1,42 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.payments.api.v3_1_8.GetDomesticPayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class GetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getDomesticPaymentApi: GetDomesticPayment
+
+    @BeforeEach
+    fun setUp() {
+        getDomesticPaymentApi = GetDomesticPayment(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetDomesticPayment", "CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"]
+    )
+    @Test
+    fun getDomesticPayments_v3_1_10() {
+        getDomesticPaymentApi.getDomesticPaymentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetDomesticPayment", "CreateDomesticPayment", "CreateDomesticPaymentConsent", "GetDomesticPaymentConsent"],
+        apis = ["domestic-payments", "domestic-payment-consents"]
+    )
+    @Test
+    @Disabled("Issue to fix this test: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/492")
+    fun shouldGetDomesticPayments_withReadRefund_v3_1_10() {
+        getDomesticPaymentApi.shouldGetDomesticPayments_withReadRefundTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/legacy/LegacyCreateDomesticPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/legacy/LegacyCreateDomesticPaymentTest.kt
@@ -25,7 +25,8 @@ import com.forgerock.uk.openbanking.support.discovery.payment3_1_3
 import com.forgerock.uk.openbanking.support.discovery.payment3_1_4
 import com.forgerock.uk.openbanking.support.payment.PaymentAS
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.mapOBWriteDomestic2DataInitiationToOBDomestic2
+import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.copyOBWriteDomestic2DataInitiation
+import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.mapOBDomestic2ToOBWriteDomestic2DataInitiation
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
@@ -91,9 +92,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload = signPayloadSubmitPayment(
@@ -177,9 +178,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                OBWriteDomestic2Data()
+                        .consentId(patchedConsent.data.consentId)
+                        .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload = signPayloadSubmitPayment(
@@ -259,9 +260,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         // When
@@ -337,9 +338,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         // When
@@ -412,9 +413,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload =
@@ -497,9 +498,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload =
@@ -581,16 +582,16 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         patchedConsent.data.consentId = INVALID_CONSENT_ID
         val paymentSubmissionWithInvalidConsentId = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload =
@@ -671,16 +672,16 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         patchedConsent.data.initiation.instructedAmount.amount = "123123"
         val paymentSubmissionInvalidAmount = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload =
@@ -762,9 +763,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload =
@@ -850,9 +851,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload =
@@ -936,9 +937,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         // When
@@ -1014,9 +1015,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         // When
@@ -1089,9 +1090,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
 
@@ -1175,9 +1176,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload =
@@ -1259,9 +1260,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload =
@@ -1343,16 +1344,16 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         patchedConsent.data.consentId = INVALID_CONSENT_ID
         val paymentSubmissionWithInvalidConsentId = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload = signPayloadSubmitPayment(
@@ -1434,16 +1435,16 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         patchedConsent.data.initiation.instructedAmount.amount = "123123"
         val paymentSubmissionInvalidAmount = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload = signPayloadSubmitPayment(
@@ -1525,9 +1526,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
+                .initiation(mapOBDomestic2ToOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload =
@@ -1613,9 +1614,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
+                OBWriteDomestic2Data()
+                        .consentId(patchedConsent.data.consentId)
+                        .initiation(mapOBDomestic2ToOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload =
@@ -1699,9 +1700,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
+                OBWriteDomestic2Data()
+                        .consentId(patchedConsent.data.consentId)
+                        .initiation(mapOBDomestic2ToOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         // When
@@ -1776,9 +1777,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
+                OBWriteDomestic2Data()
+                        .consentId(patchedConsent.data.consentId)
+                        .initiation(mapOBDomestic2ToOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         // When
@@ -1851,9 +1852,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
+                OBWriteDomestic2Data()
+                        .consentId(patchedConsent.data.consentId)
+                        .initiation(mapOBDomestic2ToOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload =
@@ -1936,9 +1937,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
+                OBWriteDomestic2Data()
+                        .consentId(patchedConsent.data.consentId)
+                        .initiation(mapOBDomestic2ToOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload =
@@ -2021,9 +2022,9 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
+                OBWriteDomestic2Data()
+                        .consentId(patchedConsent.data.consentId)
+                        .initiation(mapOBDomestic2ToOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload =
@@ -2106,16 +2107,16 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
+                OBWriteDomestic2Data()
+                        .consentId(patchedConsent.data.consentId)
+                        .initiation(mapOBDomestic2ToOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         patchedConsent.data.consentId = INVALID_CONSENT_ID
         val paymentSubmissionWithInvalidConsentId = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
+                OBWriteDomestic2Data()
+                        .consentId(patchedConsent.data.consentId)
+                        .initiation(mapOBDomestic2ToOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload = signPayloadSubmitPayment(
@@ -2197,16 +2198,16 @@ class LegacyCreateDomesticPaymentTest(val tppResource: CreateTppCallback.TppReso
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
+                OBWriteDomestic2Data()
+                        .consentId(patchedConsent.data.consentId)
+                        .initiation(mapOBDomestic2ToOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         patchedConsent.data.initiation.instructedAmount.amount = "123123"
         val paymentSubmissionInvalidAmount = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
-                .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
+                OBWriteDomestic2Data()
+                        .consentId(patchedConsent.data.consentId)
+                        .initiation(mapOBDomestic2ToOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload = signPayloadSubmitPayment(

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/legacy/LegacyGetDomesticPaymentDomesticPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/legacy/LegacyGetDomesticPaymentDomesticPaymentIdPaymentDetailsTest.kt
@@ -15,7 +15,7 @@ import com.forgerock.uk.openbanking.support.discovery.payment3_1_3
 import com.forgerock.uk.openbanking.support.discovery.payment3_1_4
 import com.forgerock.uk.openbanking.support.payment.PaymentAS
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.mapOBWriteDomestic2DataInitiationToOBDomestic2
+import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.copyOBWriteDomestic2DataInitiation
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.urlWithDomesticPaymentId
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
@@ -84,9 +84,9 @@ class LegacyGetDomesticPaymentDomesticPaymentIdPaymentDetailsTest(val tppResourc
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload = signPayloadSubmitPayment(
@@ -183,9 +183,9 @@ class LegacyGetDomesticPaymentDomesticPaymentIdPaymentDetailsTest(val tppResourc
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload =

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/legacy/LegacyGetDomesticPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/legacy/LegacyGetDomesticPaymentTest.kt
@@ -16,7 +16,8 @@ import com.forgerock.uk.openbanking.support.discovery.payment3_1_3
 import com.forgerock.uk.openbanking.support.discovery.payment3_1_4
 import com.forgerock.uk.openbanking.support.payment.PaymentAS
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory
-import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.mapOBWriteDomestic2DataInitiationToOBDomestic2
+import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.copyOBWriteDomestic2DataInitiation
+import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.mapOBDomestic2ToOBWriteDomestic2DataInitiation
 import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.urlWithDomesticPaymentId
 import com.forgerock.uk.openbanking.support.payment.PaymentRS
 import org.assertj.core.api.Assertions
@@ -84,9 +85,9 @@ class LegacyGetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResourc
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload = signPayloadSubmitPayment(
@@ -193,9 +194,9 @@ class LegacyGetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResourc
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload = signPayloadSubmitPayment(
@@ -302,9 +303,9 @@ class LegacyGetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResourc
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(mapOBWriteDomestic2DataInitiationToOBDomestic2(patchedConsent.data.initiation))
+                .initiation(copyOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload =
@@ -405,9 +406,9 @@ class LegacyGetDomesticPaymentTest(val tppResource: CreateTppCallback.TppResourc
         Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
 
         val paymentSubmissionRequest = OBWriteDomestic2().data(
-            OBWriteDataDomestic2()
+            OBWriteDomestic2Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(patchedConsent.data.initiation)
+                .initiation(mapOBDomestic2ToOBWriteDomestic2DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
 
         val signedPayload =

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/junit/v3_1_10/CreateDomesticScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/junit/v3_1_10/CreateDomesticScheduledPaymentsConsentsTest.kt
@@ -1,0 +1,96 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.consents.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.consents.api.v3_1_8.CreateDomesticScheduledPaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createDomesticScheduledPaymentsConsentsApi: CreateDomesticScheduledPaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        createDomesticScheduledPaymentsConsentsApi =
+            CreateDomesticScheduledPaymentsConsents(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun createDomesticScheduledPaymentsConsents_v3_1_10() {
+        createDomesticScheduledPaymentsConsentsApi.createDomesticScheduledPaymentsConsentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPaymentsConsents_throwsSendInvalidFormatDetachedJws_v3_1_10() {
+        createDomesticScheduledPaymentsConsentsApi.shouldCreateDomesticScheduledPaymentsConsents_throwsSendInvalidFormatDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPaymentsConsents_throwsNoDetachedJws_v3_1_10() {
+        createDomesticScheduledPaymentsConsentsApi.shouldCreateDomesticScheduledPaymentsConsents_throwsNoDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_10() {
+        createDomesticScheduledPaymentsConsentsApi.shouldCreateDomesticScheduledPaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPaymentsConsents_throwsSendInvalidKidDetachedJws_v3_1_10() {
+        createDomesticScheduledPaymentsConsentsApi.shouldCreateDomesticScheduledPaymentsConsents_throwsSendInvalidKidDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPaymentsConsents_throwsRequestExecutionTimeInThePast_v3_1_10() {
+        createDomesticScheduledPaymentsConsentsApi.shouldCreateDomesticScheduledPaymentsConsents_throwsRequestExecutionTimeInThePastTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPaymentsConsents_throwsRejectedConsent_v3_1_10() {
+        createDomesticScheduledPaymentsConsentsApi.shouldCreateDomesticScheduledPaymentsConsents_throwsRejectedConsentTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/junit/v3_1_10/GetDomesticScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/consents/junit/v3_1_10/GetDomesticScheduledPaymentsConsentsTest.kt
@@ -1,0 +1,40 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.consents.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.consents.api.v3_1_8.GetDomesticScheduledPaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetDomesticScheduledPaymentsConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getDomesticScheduledPaymentsConsentsApi: GetDomesticScheduledPaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        getDomesticScheduledPaymentsConsentsApi = GetDomesticScheduledPaymentsConsents(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldGetDomesticScheduledPaymentsConsents_v3_1_10() {
+        getDomesticScheduledPaymentsConsentsApi.shouldGetDomesticScheduledPaymentsConsentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldGetDomesticScheduledPaymentsConsents_withoutOptionalDebtorAccount_v3_1_10() {
+        getDomesticScheduledPaymentsConsentsApi.shouldGetDomesticScheduledPaymentsConsents_withoutOptionalDebtorAccountTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_10/CreateDomesticScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_10/CreateDomesticScheduledPaymentTest.kt
@@ -1,0 +1,108 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.api.v3_1_8.CreateDomesticScheduledPayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class CreateDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createDomesticScheduledPayment: CreateDomesticScheduledPayment
+
+    @BeforeEach
+    fun setUp() {
+        createDomesticScheduledPayment = CreateDomesticScheduledPayment(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun createDomesticScheduledPayments_v3_1_10() {
+        createDomesticScheduledPayment.createDomesticScheduledPaymentsTest()
+    }
+
+    @Disabled("Bug: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/336")
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPayments_throwsPaymentAlreadyExists_v3_1_10() {
+        createDomesticScheduledPayment.shouldCreateDomesticScheduledPayments_throwsPaymentAlreadyExists()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPayments_throwsSendInvalidFormatDetachedJws_v3_1_10() {
+        createDomesticScheduledPayment.shouldCreateDomesticScheduledPayments_throwsSendInvalidFormatDetachedJws()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPayments_throwsNoDetachedJws_v3_1_10() {
+        createDomesticScheduledPayment.shouldCreateDomesticScheduledPayments_throwsNoDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPayments_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_10() {
+        createDomesticScheduledPayment.shouldCreateDomesticScheduledPayments_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPayments_throwsSendInvalidKidDetachedJws_v3_1_10() {
+        createDomesticScheduledPayment.shouldCreateDomesticScheduledPayments_throwsSendInvalidKidDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_10() {
+        createDomesticScheduledPayment.shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBodyTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_10() {
+        createDomesticScheduledPayment.shouldCreateDomesticScheduledPayments_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_10/GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_10/GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest.kt
@@ -1,0 +1,25 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.api.v3_1_8.GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails
+import org.junit.jupiter.api.Test
+
+class GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetDomesticScheduledPayment", "CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun getDomesticScheduledPaymentDomesticPaymentIdPaymentDetails_v3_1_10() {
+        GetDomesticScheduledPaymentDomesticPaymentIdPaymentDetails(
+            OBVersion.v3_1_10,
+            tppResource
+        ).getDomesticScheduledPaymentDomesticPaymentIdPaymentDetailsTest()
+    }
+
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_10/GetDomesticScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/scheduled/payments/junit/v3_1_10/GetDomesticScheduledPaymentTest.kt
@@ -1,0 +1,42 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.scheduled.payments.api.v3_1_8.GetDomesticScheduledPayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class GetDomesticScheduledPaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getDomesticScheduledPayment: GetDomesticScheduledPayment
+
+    @BeforeEach
+    fun setUp() {
+        getDomesticScheduledPayment = GetDomesticScheduledPayment(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetDomesticScheduledPayment", "CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
+    )
+    @Test
+    fun getDomesticScheduledPayments_v3_1_10() {
+        getDomesticScheduledPayment.getDomesticScheduledPaymentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetDomesticScheduledPayment", "CreateDomesticScheduledPayment", "CreateDomesticScheduledPaymentConsent", "GetDomesticScheduledPaymentConsent"],
+        apis = ["domestic-scheduled-payments", "domestic-scheduled-payment-consents"]
+    )
+    @Disabled
+    @Test
+    fun shouldGetDomesticScheduledPayments_withReadRefund_v3_1_10() {
+        getDomesticScheduledPayment.shouldGetDomesticScheduledPayments_withReadRefundTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/api/v3_1_8/CreateDomesticStandingOrder.kt
@@ -19,15 +19,11 @@ import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
 import com.forgerock.uk.openbanking.support.payment.BadJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.DefaultJwsSignatureProducer
 import com.forgerock.uk.openbanking.support.payment.InvalidKidJwsSignatureProducer
-import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.copyOBWriteDomesticStandingOrder3DataInitiation
+import com.forgerock.uk.openbanking.support.payment.PaymentFactory.Companion.mapOBWriteDomesticStandingOrderConsentResponse6DataInitiationToOBWriteDomesticStandingOrder3DataInitiation
 import com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.consents.api.v3_1_8.CreateDomesticStandingOrderConsents
 import com.github.kittinunf.fuel.core.FuelError
 import org.assertj.core.api.Assertions
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3Data
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse6
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderResponse6
+import uk.org.openbanking.datamodel.payment.*
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsentTestDataFactory
 
 class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
@@ -299,7 +295,7 @@ class CreateDomesticStandingOrder(val version: OBVersion, val tppResource: Creat
         return OBWriteDomesticStandingOrder3().data(
             OBWriteDomesticStandingOrder3Data()
                 .consentId(patchedConsent.data.consentId)
-                .initiation(copyOBWriteDomesticStandingOrder3DataInitiation(patchedConsent.data.initiation))
+                .initiation(mapOBWriteDomesticStandingOrderConsentResponse6DataInitiationToOBWriteDomesticStandingOrder3DataInitiation(patchedConsent.data.initiation))
         ).risk(patchedConsent.risk)
     }
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/junit/v3_1_10/CreateDomesticStandingOrderConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/junit/v3_1_10/CreateDomesticStandingOrderConsentsTest.kt
@@ -1,0 +1,106 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.consents.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.consents.api.v3_1_8.CreateDomesticStandingOrderConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createDomesticStandingOrderConsents: CreateDomesticStandingOrderConsents
+
+    @BeforeEach
+    fun setUp() {
+        createDomesticStandingOrderConsents = CreateDomesticStandingOrderConsents(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun createDomesticStandingOrdersConsents_v3_1_10() {
+        createDomesticStandingOrderConsents.createDomesticStandingOrdersConsentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun createDomesticStandingOrdersConsents_mandatoryFields_v3_1_10() {
+        createDomesticStandingOrderConsents.createDomesticStandingOrdersConsents_mandatoryFields()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsInvalidFrequencyValue_v3_1_10() {
+        createDomesticStandingOrderConsents.shouldCreateDomesticStandingOrdersConsents_throwsInvalidFrequencyValue()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidFormatDetachedJws_v3_1_10() {
+        createDomesticStandingOrderConsents.shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidFormatDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsNoDetachedJws_v3_1_10() {
+        createDomesticStandingOrderConsents.shouldCreateDomesticStandingOrdersConsents_throwsNoDetachedJws()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_10() {
+        createDomesticStandingOrderConsents.shouldCreateDomesticStandingOrdersConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidKidDetachedJws_v3_1_10() {
+        createDomesticStandingOrderConsents.shouldCreateDomesticStandingOrdersConsents_throwsSendInvalidKidDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrdersConsents_throwsRejectedConsent_v3_1_10() {
+        createDomesticStandingOrderConsents.shouldCreateDomesticStandingOrdersConsents_throwsRejectedConsentTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/junit/v3_1_10/GetDomesticStandingOrderConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/consents/junit/v3_1_10/GetDomesticStandingOrderConsentsTest.kt
@@ -1,0 +1,29 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.consents.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.consents.api.v3_1_8.GetDomesticStandingOrderConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetDomesticStandingOrderConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getDomesticStandingOrderConsents: GetDomesticStandingOrderConsents
+
+    @BeforeEach
+    fun setUp() {
+        getDomesticStandingOrderConsents = GetDomesticStandingOrderConsents(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
+    )
+    @Test
+    fun createDomesticStandingOrder_v3_1_10() {
+        getDomesticStandingOrderConsents.shouldGetDomesticStandingOrdersConsents_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/junit/v3_1_10/CreateDomesticStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/junit/v3_1_10/CreateDomesticStandingOrderTest.kt
@@ -1,0 +1,119 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.api.v3_1_8.CreateDomesticStandingOrder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class CreateDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createDomesticStandingOrder: CreateDomesticStandingOrder
+
+    @BeforeEach
+    fun setUp() {
+        createDomesticStandingOrder = CreateDomesticStandingOrder(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
+    )
+    @Test
+    fun createDomesticStandingOrder_v3_1_10() {
+        createDomesticStandingOrder.createDomesticStandingOrderTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
+    )
+    @Test
+    fun createDomesticStandingOrder_mandatoryFields_v3_1_10() {
+        createDomesticStandingOrder.createDomesticStandingOrder_mandatoryFieldsTest()
+    }
+
+    @Disabled("Bug: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/336")
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrder_throwsStandingOrderAlreadyExists_v3_1_10() {
+        createDomesticStandingOrder.shouldCreateDomesticStandingOrder_throwsStandingOrderAlreadyExistsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrder_throwsSendInvalidFormatDetachedJws_v3_1_10() {
+        createDomesticStandingOrder.shouldCreateDomesticStandingOrder_throwsSendInvalidFormatDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrder_throwsNoDetachedJws_v3_1_10() {
+        createDomesticStandingOrder.shouldCreateDomesticStandingOrder_throwsNoDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrder_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_10() {
+        createDomesticStandingOrder.shouldCreateDomesticStandingOrder_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrder_throwsSendInvalidKidDetachedJws_v3_1_10() {
+        createDomesticStandingOrder.shouldCreateDomesticStandingOrder_throwsSendInvalidKidDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_10() {
+        createDomesticStandingOrder.shouldCreateDomesticStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBodyTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
+    )
+    @Test
+    fun shouldCreateDomesticStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_10() {
+        createDomesticStandingOrder.shouldCreateDomesticStandingOrder_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBodyTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/junit/v3_1_10/GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/junit/v3_1_10/GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest.kt
@@ -1,0 +1,41 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.api.v3_1_8.GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails: GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails
+
+    @BeforeEach
+    fun setUp() {
+        getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails =
+            GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetDomesticStandingOrder", "CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent", "GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
+    )
+    @Test
+    fun getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails_v3_1_10() {
+        getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails.getDomesticStandingOrderDomesticStandingOrderIdPaymentDetailsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetDomesticStandingOrder", "CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent", "GetDomesticStandingOrderDomesticStandingOrderIdPaymentDetails"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
+    )
+    @Test
+    fun getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails_v3_1_10_mandatoryFields() {
+        getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails.getDomesticStandingOrderDomesticStandingOrderIdPaymentDetails_mandatoryFieldsTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/junit/v3_1_10/GetDomesticStandingOrderTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/standing/order/junit/v3_1_10/GetDomesticStandingOrderTest.kt
@@ -1,0 +1,54 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.domestic.standing.order.api.v3_1_8.GetDomesticStandingOrder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class GetDomesticStandingOrderTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getDomesticStandingOrder: GetDomesticStandingOrder
+
+    @BeforeEach
+    fun setUp() {
+        getDomesticStandingOrder = GetDomesticStandingOrder(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetDomesticStandingOrder", "CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
+    )
+    @Test
+    fun getDomesticStandingOrders_v3_1_10() {
+        getDomesticStandingOrder.getDomesticStandingOrdersTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetDomesticStandingOrder", "CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
+    )
+    @Test
+    fun getDomesticStandingOrders_v3_1_10_mandatoryFields() {
+        getDomesticStandingOrder.getDomesticStandingOrders_mandatoryFieldsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetDomesticStandingOrder", "CreateDomesticStandingOrder", "CreateDomesticStandingOrderConsent", "GetDomesticStandingOrderConsent"],
+        apis = ["domestic-standing-orders", "domestic-standing-order-consents"]
+    )
+    @Disabled
+    @Test
+    fun shouldGetDomesticStandingOrders_withReadRefund_v3_1_10() {
+        getDomesticStandingOrder.shouldGetDomesticStandingOrders_withReadRefundTest()
+    }
+
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsentFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/api/v3_1_8/GetInternationalPaymentsConsentFundsConfirmation.kt
@@ -34,7 +34,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -53,7 +53,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -72,7 +72,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -89,7 +89,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -108,7 +108,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -127,7 +127,7 @@ class GetInternationalPaymentsConsentFundsConfirmation(
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_10/CreateInternationalPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_10/CreateInternationalPaymentsConsentsTest.kt
@@ -1,0 +1,95 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.api.v3_1_8.CreateInternationalPaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createInternationalPaymentsConsents: CreateInternationalPaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        createInternationalPaymentsConsents = CreateInternationalPaymentsConsents(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun createInternationalPaymentsConsents_v3_1_10() {
+        createInternationalPaymentsConsents.createInternationalPaymentsConsents()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun createInternationalPaymentsConsents_mandatoryFields_v3_1_10() {
+        createInternationalPaymentsConsents.createInternationalPaymentsConsents_mandatoryFieldsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalPaymentConsents_throwsSendInvalidFormatDetachedJws_v3_1_10() {
+        createInternationalPaymentsConsents.shouldCreateInternationalPaymentConsents_throwsSendInvalidFormatDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalPaymentConsents_throwsNoDetachedJws_v3_1_10() {
+        createInternationalPaymentsConsents.shouldCreateInternationalPaymentConsents_throwsNoDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalPaymentConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_10() {
+        createInternationalPaymentsConsents.shouldCreateInternationalPaymentConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalPaymentConsents_throwsSendInvalidKidDetachedJws_v3_1_10() {
+        createInternationalPaymentsConsents.shouldCreateInternationalPaymentConsents_throwsSendInvalidKidDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalPaymentConsents_throwsRejectedConsent_v3_1_10() {
+        createInternationalPaymentsConsents.shouldCreateInternationalPaymentConsents_throwsRejectedConsent_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_10/GetInternationalPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_10/GetInternationalPaymentsConsentFundsConfirmationTest.kt
@@ -1,0 +1,111 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.api.v3_1_8.GetInternationalPaymentsConsentFundsConfirmation
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+@Disabled("Not implemented")
+class GetInternationalPaymentsConsentFundsConfirmationTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getInternationalPaymentsConsentFundsConfirmation: GetInternationalPaymentsConsentFundsConfirmation
+
+    @BeforeEach
+    fun setUp() {
+        getInternationalPaymentsConsentFundsConfirmation =
+            GetInternationalPaymentsConsentFundsConfirmation(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentConsentsFundsConfirmation_true_rateType_AGREED_v3_1_10() {
+        getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_true_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentConsentsFundsConfirmation_true_rateType_ACTUAL_v3_1_10() {
+        getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_true_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentConsentsFundsConfirmation_true_rateType_INDICATIVE_v3_1_10() {
+        getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_true_rateType_INDICATIVE_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentConsentsFundsConfirmation_false_rateType_AGREED_v3_1_10() {
+        getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_false_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentConsentsFundsConfirmation_false_rateType_ACTUAL_v3_1_10() {
+        getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_false_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentConsentsFundsConfirmation_false_rateType_INDICATIVE_v3_1_10() {
+        getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_false_rateType_INDICATIVE_Test()
+    }
+
+    @Disabled("Enhancement: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/337")
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentConsentsFundsConfirmation_throwsWrongGrantType_v3_1_10() {
+        getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_throwsWrongGrantType_Test()
+    }
+
+    
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_v3_1_10() {
+        getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_10/GetInternationalPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_10/GetInternationalPaymentsConsentsTest.kt
@@ -1,0 +1,51 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.consents.api.v3_1_8.GetInternationalPaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetInternationalPaymentsConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getInternationalPaymentsConsents: GetInternationalPaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        getInternationalPaymentsConsents = GetInternationalPaymentsConsents(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentsConsents_rateType_AGREED_v3_1_10() {
+        getInternationalPaymentsConsents.shouldGetInternationalPaymentsConsents_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentsConsents_rateType_ACTUAL_v3_1_10() {
+        getInternationalPaymentsConsents.shouldGetInternationalPaymentsConsents_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalPaymentsConsents_rateType_INDICATIVE_v3_1_10() {
+        getInternationalPaymentsConsents.shouldGetInternationalPaymentsConsents_rateType_INDICATIVE_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/legacy/LegacyGetInternationalPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/legacy/LegacyGetInternationalPaymentsConsentFundsConfirmationTest.kt
@@ -83,7 +83,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -143,7 +143,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -203,7 +203,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -262,7 +262,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -322,7 +322,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -382,7 +382,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -584,7 +584,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -644,7 +644,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -704,7 +704,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -763,7 +763,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -823,7 +823,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -883,7 +883,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1087,7 +1087,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1147,7 +1147,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1207,7 +1207,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1266,7 +1266,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1326,7 +1326,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1386,7 +1386,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1590,7 +1590,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1651,7 +1651,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1712,7 +1712,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1772,7 +1772,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1833,7 +1833,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1894,7 +1894,7 @@ class LegacyGetInternationalPaymentsConsentFundsConfirmationTest(val tppResource
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/junit/v3_1_10/CreateInternationalPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/junit/v3_1_10/CreateInternationalPaymentTest.kt
@@ -1,0 +1,139 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.payments.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.api.v3_1_8.CreateInternationalPayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createInternationalPayment: CreateInternationalPayment
+
+    @BeforeEach
+    fun setUp() {
+        createInternationalPayment = CreateInternationalPayment(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun createInternationalPayment_rateType_AGREED_v3_1_10() {
+        createInternationalPayment.createInternationalPayment_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun createInternationalPayment_rateType_ACTUAL_v3_1_10() {
+        createInternationalPayment.createInternationalPayment_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun createInternationalPayment_rateType_INDICATIVE_v3_1_10() {
+        createInternationalPayment.createInternationalPayment_rateType_INDICATIVE_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun createInternationalPayment_mandatoryFields_v3_1_10() {
+        createInternationalPayment.createInternationalPayment_mandatoryFields_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalPayment_throwsInternationalPaymentAlreadyExists_v3_1_10() {
+        createInternationalPayment.shouldCreateInternationalPayment_throwsInternationalPaymentAlreadyExists_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalPayment_throwsSendInvalidFormatDetachedJws_v3_1_10() {
+        createInternationalPayment.shouldCreateInternationalPayment_throwsSendInvalidFormatDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalPayment_throwsNoDetachedJws_v3_1_10() {
+        createInternationalPayment.shouldCreateInternationalPayment_throwsNoDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalPayment_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_10() {
+        createInternationalPayment.shouldCreateInternationalPayment_throwsNotPermittedB64HeaderAddedInTheDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalPayment_throwsSendInvalidKidDetachedJws_v3_1_10() {
+        createInternationalPayment.shouldCreateInternationalPayment_throwsSendInvalidKidDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_10() {
+        createInternationalPayment.shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_10() {
+        createInternationalPayment.shouldCreateInternationalPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/junit/v3_1_10/GetInternationalPaymentInternationalPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/junit/v3_1_10/GetInternationalPaymentInternationalPaymentIdPaymentDetailsTest.kt
@@ -1,0 +1,63 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.payments.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.api.v3_1_8.GetInternationalPaymentInternationalPaymentIdPaymentDetails
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetInternationalPaymentInternationalPaymentIdPaymentDetailsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getInternationalPaymentInternationalPaymentIdPaymentDetails: GetInternationalPaymentInternationalPaymentIdPaymentDetails
+
+    @BeforeEach
+    fun setUp() {
+        getInternationalPaymentInternationalPaymentIdPaymentDetails =
+            GetInternationalPaymentInternationalPaymentIdPaymentDetails(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent", "GetInternationalPaymentInternationalPaymentIdPaymentDetails"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_AGREED_v3_1_10() {
+        getInternationalPaymentInternationalPaymentIdPaymentDetails.getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent", "GetInternationalPaymentInternationalPaymentIdPaymentDetails"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_ACTUAL_v3_1_10() {
+        getInternationalPaymentInternationalPaymentIdPaymentDetails.getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent", "GetInternationalPaymentInternationalPaymentIdPaymentDetails"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_INDICATIVE_v3_1_10() {
+        getInternationalPaymentInternationalPaymentIdPaymentDetails.getInternationalPaymentInternationalPaymentIdPaymentDetails_rateType_INDICATIVE_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent", "GetInternationalPaymentInternationalPaymentIdPaymentDetails"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun getInternationalPaymentInternationalPaymentIdPaymentDetails_v3_1_10_mandatoryFields() {
+        getInternationalPaymentInternationalPaymentIdPaymentDetails.getInternationalPaymentInternationalPaymentIdPaymentDetails_mandatoryFields_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/junit/v3_1_10/GetInternationalPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/junit/v3_1_10/GetInternationalPaymentTest.kt
@@ -1,0 +1,75 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.payments.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.payments.api.v3_1_8.GetInternationalPayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class GetInternationalPaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getInternationalPayment: GetInternationalPayment
+
+    @BeforeEach
+    fun setUp() {
+        getInternationalPayment = GetInternationalPayment(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun getInternationalPayments_rateType_AGREED_v3_1_10() {
+        getInternationalPayment.getInternationalPayments_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun getInternationalPayments_rateType_ACTUAL_v3_1_10() {
+        getInternationalPayment.getInternationalPayments_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun getInternationalPayments_rateType_INDICATIVE_v3_1_10() {
+        getInternationalPayment.getInternationalPayments_rateType_INDICATIVE_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun getInternationalPayments_v3_1_10_mandatoryFields() {
+        getInternationalPayment.getInternationalPayments_mandatoryFields_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetInternationalPayment", "CreateInternationalPayment", "CreateInternationalPaymentConsent", "GetInternationalPaymentConsent"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Disabled
+    @Test
+    fun shouldGetInternationalPayments_withReadRefund_v3_1_10() {
+        getInternationalPayment.shouldGetInternationalPayments_withReadRefund_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/GetInternationalScheduledPaymentsConsentFundsConfirmation.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/api/v3_1_8/GetInternationalScheduledPaymentsConsentFundsConfirmation.kt
@@ -35,7 +35,7 @@ class GetInternationalScheduledPaymentsConsentFundsConfirmation(
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -54,7 +54,7 @@ class GetInternationalScheduledPaymentsConsentFundsConfirmation(
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -73,7 +73,7 @@ class GetInternationalScheduledPaymentsConsentFundsConfirmation(
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -90,7 +90,7 @@ class GetInternationalScheduledPaymentsConsentFundsConfirmation(
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -109,7 +109,7 @@ class GetInternationalScheduledPaymentsConsentFundsConfirmation(
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -128,7 +128,7 @@ class GetInternationalScheduledPaymentsConsentFundsConfirmation(
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_10/CreateInternationalScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_10/CreateInternationalScheduledPaymentsConsentsTest.kt
@@ -1,0 +1,107 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.consents.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.consents.api.v3_1_8.CreateInternationalScheduledPaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createInternationalScheduledPaymentsConsents: CreateInternationalScheduledPaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        createInternationalScheduledPaymentsConsents =
+            CreateInternationalScheduledPaymentsConsents(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun createInternationalScheduledPaymentsConsents_v3_1_10() {
+        createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentsConsentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun createInternationalScheduledPaymentsConsents_mandatoryFields_v3_1_10() {
+        createInternationalScheduledPaymentsConsents.createInternationalScheduledPaymentsConsents_mandatoryFields_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPaymentConsents_throwsSendInvalidFormatDetachedJws_v3_1_10() {
+        createInternationalScheduledPaymentsConsents.shouldCreateInternationalScheduledPaymentConsents_throwsSendInvalidFormatDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPaymentConsents_throwsNoDetachedJws_v3_1_10() {
+        createInternationalScheduledPaymentsConsents.shouldCreateInternationalScheduledPaymentConsents_throwsNoDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPaymentConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_10() {
+        createInternationalScheduledPaymentsConsents.shouldCreateInternationalScheduledPaymentConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPaymentConsents_throwsSendInvalidKidDetachedJws_v3_1_10() {
+        createInternationalScheduledPaymentsConsents.shouldCreateInternationalScheduledPaymentConsents_throwsSendInvalidKidDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPaymentConsents_throwsRequestExecutionTimeInThePast_v3_1_10() {
+        createInternationalScheduledPaymentsConsents.shouldCreateInternationalScheduledPaymentConsents_throwsRequestExecutionTimeInThePast_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPaymentConsents_throwsRejectedConsent_v3_1_10() {
+        createInternationalScheduledPaymentsConsents.shouldCreateInternationalScheduledPaymentConsents_throwsRejectedConsent_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_10/GetInternationalScheduledPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_10/GetInternationalScheduledPaymentsConsentFundsConfirmationTest.kt
@@ -1,0 +1,110 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.consents.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.consents.api.v3_1_8.GetInternationalScheduledPaymentsConsentFundsConfirmation
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+@Disabled("Not implemented")
+class GetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tppResource: CreateTppCallback.TppResource) {
+
+    private lateinit var getInternationalScheduledPaymentsConsentFundsConfirmation: GetInternationalScheduledPaymentsConsentFundsConfirmation
+
+    @BeforeEach
+    fun setUp() {
+        getInternationalScheduledPaymentsConsentFundsConfirmation =
+            GetInternationalScheduledPaymentsConsentFundsConfirmation(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_true_rateType_AGREED_v3_1_10() {
+        getInternationalScheduledPaymentsConsentFundsConfirmation.shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_true_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_true_rateType_ACTUAL_v3_1_10() {
+        getInternationalScheduledPaymentsConsentFundsConfirmation.shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_true_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_true_rateType_INDICATIVE_v3_1_10() {
+        getInternationalScheduledPaymentsConsentFundsConfirmation.shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_true_rateType_INDICATIVE_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_false_rateType_AGREED_v3_1_10() {
+        getInternationalScheduledPaymentsConsentFundsConfirmation.shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_false_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_false_rateType_ACTUAL_v3_1_10() {
+        getInternationalScheduledPaymentsConsentFundsConfirmation.shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_false_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_false_rateType_INDICATIVE_v3_1_10() {
+        getInternationalScheduledPaymentsConsentFundsConfirmation.shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_false_rateType_INDICATIVE_Test()
+    }
+
+    @Disabled("Enhancement: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/337")
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_throwsWrongGrantType_v3_1_10() {
+        getInternationalScheduledPaymentsConsentFundsConfirmation.shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_throwsWrongGrantType_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsentsConsentIdFundsConfirmation"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_v3_1_10() {
+        getInternationalScheduledPaymentsConsentFundsConfirmation.shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_throwsInvalidConsentStatus_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_10/GetInternationalScheduledPaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_10/GetInternationalScheduledPaymentsConsentsTest.kt
@@ -1,0 +1,52 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.consents.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.consents.api.v3_1_8.GetInternationalScheduledPaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetInternationalScheduledPaymentsConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getInternationalScheduledPaymentsConsentsTest: GetInternationalScheduledPaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        getInternationalScheduledPaymentsConsentsTest =
+            GetInternationalScheduledPaymentsConsents(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalScheduledPaymentsConsents_rateType_AGREED_v3_1_10() {
+        getInternationalScheduledPaymentsConsentsTest.shouldGetInternationalScheduledPaymentsConsents_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalScheduledPaymentsConsents_rateType_ACTUAL_v3_1_10() {
+        getInternationalScheduledPaymentsConsentsTest.shouldGetInternationalScheduledPaymentsConsents_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldGetInternationalScheduledPaymentsConsents_rateType_INDICATIVE_v3_1_10() {
+        getInternationalScheduledPaymentsConsentsTest.shouldGetInternationalScheduledPaymentsConsents_rateType_INDICATIVE_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/legacy/LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/legacy/LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest.kt
@@ -83,7 +83,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -143,7 +143,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -203,7 +203,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -262,7 +262,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -322,7 +322,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -382,7 +382,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -584,7 +584,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -644,7 +644,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -704,7 +704,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -763,7 +763,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -823,7 +823,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -883,7 +883,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1087,7 +1087,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1147,7 +1147,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1207,7 +1207,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1266,7 +1266,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1326,7 +1326,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1386,7 +1386,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1590,7 +1590,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1651,7 +1651,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1712,7 +1712,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isTrue()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isTrue()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1772,7 +1772,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1833,7 +1833,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 
@@ -1894,7 +1894,7 @@ class LegacyGetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tp
         assertThat(result).isNotNull()
         assertThat(result.data).isNotNull()
         assertThat(result.data.fundsAvailableResult).isNotNull()
-        assertThat(result.data.fundsAvailableResult.isFundsAvailable).isFalse()
+        assertThat(result.data.fundsAvailableResult.fundsAvailable).isFalse()
         assertThat(result.data.fundsAvailableResult.fundsAvailableDateTime).isNotNull()
     }
 

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/junit/v3_1_10/CreateInternationalScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/junit/v3_1_10/CreateInternationalScheduledPaymentTest.kt
@@ -1,0 +1,141 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.api.v3_1_8.CreateInternationalScheduledPayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class CreateInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var createInternationalScheduledPayment: CreateInternationalScheduledPayment
+
+    @BeforeEach
+    fun setUp() {
+        createInternationalScheduledPayment = CreateInternationalScheduledPayment(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
+    )
+    @Test
+    fun createInternationalScheduledPayment_rateType_AGREED_v3_1_10() {
+        createInternationalScheduledPayment.createInternationalScheduledPayment_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
+    )
+    @Test
+    fun createInternationalScheduledPayment_rateType_ACTUAL_v3_1_10() {
+        createInternationalScheduledPayment.createInternationalScheduledPayment_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
+    )
+    @Test
+    fun createInternationalScheduledPayment_rateType_INDICATIVE_v3_1_10() {
+        createInternationalScheduledPayment.createInternationalScheduledPayment_rateType_INDICATIVE_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
+    )
+    @Test
+    fun createInternationalScheduledPayment_mandatoryFields_v3_1_10() {
+        createInternationalScheduledPayment.createInternationalScheduledPayment_mandatoryFields_Test()
+    }
+
+    @Disabled("Bug: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/336")
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPayment_throwsInternationalScheduledPaymentAlreadyExists_v3_1_10() {
+        createInternationalScheduledPayment.shouldCreateInternationalScheduledPayment_throwsInternationalScheduledPaymentAlreadyExists_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPayment_throwsSendInvalidFormatDetachedJws_v3_1_10() {
+        createInternationalScheduledPayment.shouldCreateInternationalScheduledPayment_throwsSendInvalidFormatDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPayment_throwsNoDetachedJws_v3_1_10() {
+        createInternationalScheduledPayment.shouldCreateInternationalScheduledPayment_throwsNoDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPayment_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_10() {
+        createInternationalScheduledPayment.shouldCreateInternationalScheduledPayment_throwsNotPermittedB64HeaderAddedInTheDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPayment_throwsSendInvalidKidDetachedJws_v3_1_10() {
+        createInternationalScheduledPayment.shouldCreateInternationalScheduledPayment_throwsSendInvalidKidDetachedJws_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_v3_1_10() {
+        createInternationalScheduledPayment.shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentConsentIdThanTheBody_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
+    )
+    @Test
+    fun shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_v3_1_10() {
+        createInternationalScheduledPayment.shouldCreateInternationalScheduledPayment_throwsInvalidDetachedJws_detachedJwsHasDifferentAmountThanTheBody_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/junit/v3_1_10/GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetailsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/junit/v3_1_10/GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetailsTest.kt
@@ -1,0 +1,63 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.api.v3_1_8.GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetailsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails: GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails
+
+    @BeforeEach
+    fun setUp() {
+        getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails =
+            GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_AGREED_v3_1_10() {
+        getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails.getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_ACTUAL_v3_1_10() {
+        getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails.getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_INDICATIVE_v3_1_10() {
+        getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails.getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_rateType_INDICATIVE_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails"],
+        apis = ["international-payments", "international-payment-consents"]
+    )
+    @Test
+    fun getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_v3_1_10_mandatoryFields() {
+        getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails.getInternationalScheduledPaymentInternationalScheduledPaymentIdPaymentDetails_Test()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/junit/v3_1_10/GetInternationalScheduledPaymentTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/junit/v3_1_10/GetInternationalScheduledPaymentTest.kt
@@ -1,0 +1,75 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.international.scheduled.payments.api.v3_1_8.GetInternationalScheduledPayment
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class GetInternationalScheduledPaymentTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getInternationalScheduledPayment: GetInternationalScheduledPayment
+
+    @BeforeEach
+    fun setUp() {
+        getInternationalScheduledPayment = GetInternationalScheduledPayment(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
+    )
+    @Test
+    fun getInternationalScheduledPayments_rateType_AGREED_v3_1_10() {
+        getInternationalScheduledPayment.getInternationalScheduledPayments_rateType_AGREED_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
+    )
+    @Test
+    fun getInternationalScheduledPayments_rateType_ACTUAL_v3_1_10() {
+        getInternationalScheduledPayment.getInternationalScheduledPayments_rateType_ACTUAL_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
+    )
+    @Test
+    fun getInternationalScheduledPayments_rateType_INDICATIVE_v3_1_10() {
+        getInternationalScheduledPayment.getInternationalScheduledPayments_rateType_INDICATIVE_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
+    )
+    @Test
+    fun getInternationalScheduledPayments_v3_1_10_mandatoryFields() {
+        getInternationalScheduledPayment.getInternationalScheduledPayments_mandatoryFields_Test()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["GetInternationalScheduledPayment", "CreateInternationalScheduledPayment", "CreateInternationalScheduledPaymentConsent", "GetInternationalScheduledPaymentConsent"],
+        apis = ["international-scheduled-payments", "international-scheduled-payment-consents"]
+    )
+    @Disabled
+    @Test
+    fun shouldGetInternationalScheduledPayments_withReadRefund_v3_1_10() {
+        getInternationalScheduledPayment.shouldGetInternationalScheduledPayments_withReadRefund_Test()
+    }
+}


### PR DESCRIPTION
- Updating datamodel dependency to use 3.1.10
- Updating test code to be compatible with new data model
- Adding 3.1.10 JUnit tests for existing functionality (as a clone of 3.1.8)
- Adding 3.1.10 gradle test tasks

https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/424