### PR TITLE
513: Cleaning test reports from codefresh volume at the start of each build

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -30,7 +30,9 @@ steps:
         
         set -x
         echo "Copying test reports to CF volume"
-        mkdir /codefresh/volume/test-reports/
+        # volume is shared by subsequent builds, clear test report output
+        rm -rf /codefresh/volume/test-reports/*
+        mkdir -p /codefresh/volume/test-reports/
         cp -r ./build/reports/tests /codefresh/volume/test-reports/
         exit ${gradle_exit_code}
 


### PR DESCRIPTION
Codefresh volumes are shared between build steps and also reused between build pipeline runs. This change cleans up the test-eports dir in the volume to prevent old reports being copied to GCP.

https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/513