### PR TITLE
337: Adding functional tests for grant type verifier

### DIFF
--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_8/GetDomesticPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_8/GetDomesticPaymentsConsentFundsConfirmationTest.kt
@@ -30,7 +30,6 @@ class GetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: CreateTpp
         getDomesticPaymentsConsentFundsConfirmationApi.shouldGetDomesticPaymentConsentsFundsConfirmation_false()
     }
 
-    @Disabled("Enhancement: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/337")
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.8",

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_8/GetInternationalPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_8/GetInternationalPaymentsConsentFundsConfirmationTest.kt
@@ -91,7 +91,6 @@ class GetInternationalPaymentsConsentFundsConfirmationTest(val tppResource: Crea
         getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_false_rateType_INDICATIVE_Test()
     }
 
-    @Disabled("Enhancement: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/337")
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.8",

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_8/GetInternationalScheduledPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_8/GetInternationalScheduledPaymentsConsentFundsConfirmationTest.kt
@@ -91,7 +91,6 @@ class GetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tppResou
         getInternationalScheduledPaymentsConsentFundsConfirmation.shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_false_rateType_INDICATIVE_Test()
     }
 
-    @Disabled("Enhancement: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/337")
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.8",


### PR DESCRIPTION
Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/337 
Description: Added the functional tests for the grant type verifier filter that were initially disabled as a future enhancement.
The functional tests for both international payment consents funds confirmation & international scheduled payment consents funds confirmation are being ignored as not implemented yet.