### PR TITLE
Adding v3_1_9 & v3_1_10 functional tests for grant type verifier

### DIFF
--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_10/GetDomesticPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_10/GetDomesticPaymentsConsentFundsConfirmationTest.kt
@@ -29,7 +29,6 @@ class GetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: CreateTpp
         getDomesticPaymentsConsentFundsConfirmationApi.shouldGetDomesticPaymentConsentsFundsConfirmation_false()
     }
 
-    @Disabled("Enhancement: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/337")
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_9/GetDomesticPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/domestic/payments/consents/junit/v3_1_9/GetDomesticPaymentsConsentFundsConfirmationTest.kt
@@ -29,7 +29,6 @@ class GetDomesticPaymentsConsentFundsConfirmationTest(val tppResource: CreateTpp
         getDomesticPaymentsConsentFundsConfirmationApi.shouldGetDomesticPaymentConsentsFundsConfirmation_false()
     }
 
-    @Disabled("Enhancement: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/337")
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.9",

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_10/GetInternationalPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_10/GetInternationalPaymentsConsentFundsConfirmationTest.kt
@@ -85,7 +85,6 @@ class GetInternationalPaymentsConsentFundsConfirmationTest(val tppResource: Crea
         getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_false_rateType_INDICATIVE_Test()
     }
 
-    @Disabled("Enhancement: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/337")
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_9/GetInternationalPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/payments/consents/junit/v3_1_9/GetInternationalPaymentsConsentFundsConfirmationTest.kt
@@ -85,7 +85,6 @@ class GetInternationalPaymentsConsentFundsConfirmationTest(val tppResource: Crea
         getInternationalPaymentsConsentFundsConfirmation.shouldGetInternationalPaymentConsentsFundsConfirmation_false_rateType_INDICATIVE_Test()
     }
 
-    @Disabled("Enhancement: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/337")
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.9",

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_10/GetInternationalScheduledPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_10/GetInternationalScheduledPaymentsConsentFundsConfirmationTest.kt
@@ -85,7 +85,6 @@ class GetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tppResou
         getInternationalScheduledPaymentsConsentFundsConfirmation.shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_false_rateType_INDICATIVE_Test()
     }
 
-    @Disabled("Enhancement: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/337")
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.10",

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_9/GetInternationalScheduledPaymentsConsentFundsConfirmationTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/international/scheduled/payments/consents/junit/v3_1_9/GetInternationalScheduledPaymentsConsentFundsConfirmationTest.kt
@@ -85,7 +85,6 @@ class GetInternationalScheduledPaymentsConsentFundsConfirmationTest(val tppResou
         getInternationalScheduledPaymentsConsentFundsConfirmation.shouldGetInternationalScheduledPaymentConsentsFundsConfirmation_false_rateType_INDICATIVE_Test()
     }
 
-    @Disabled("Enhancement: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/337")
     @EnabledIfVersion(
         type = "payments",
         apiVersion = "v3.1.9",


### PR DESCRIPTION
Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/337
Description: Added v3_1_9 & v3_1_10 functional tests for the grant type verifier filter that were initially disabled as a future enhancement.
The functional tests for both international payment consents funds confirmation & international scheduled payment consents funds confirmation are being ignored as not implemented yet.