### PR TITLE
537: Fixing test for delete account access consent to match OB spec behaviour

### DIFF
--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/access/consents/AccountAccessConsentApi.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/access/consents/AccountAccessConsentApi.kt
@@ -7,6 +7,6 @@ import uk.org.openbanking.datamodel.account.OBReadConsentResponse1
 interface AccountAccessConsentApi {
     fun createConsent(permissions: List<OBExternalPermissions1Code>): OBReadConsentResponse1
     fun createConsentAndGetAccessToken(permissions: List<OBExternalPermissions1Code>): Pair<OBReadConsentResponse1, AccessToken>
-    fun deleteConsent(consentId: String): OBReadConsentResponse1
+    fun deleteConsent(consentId: String)
     fun getConsent(consentId: String): OBReadConsentResponse1
 }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/access/consents/api/v3_1_8/AccountAccessConsent.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/account/access/consents/api/v3_1_8/AccountAccessConsent.kt
@@ -40,13 +40,7 @@ class AccountAccessConsent(val version: OBVersion, val tppResource: CreateTppCal
         // Given
         val consent = createConsent(listOf(OBExternalPermissions1Code.READACCOUNTSDETAIL))
         // When
-        val deletedConsent = deleteConsent(consent.data.consentId)
-
-        // Then
-        assertThat(deletedConsent).isNotNull()
-        assertThat(deletedConsent.data).isNotNull()
-        assertThat(deletedConsent.data.consentId).isEqualTo(consent.data.consentId)
-        Assertions.assertThat(deletedConsent.data.status.toString()).`is`(Status.consentCondition)
+        deleteConsent(consent.data.consentId)
 
         // Verify we cannot get the consent anymore
         val error = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
@@ -86,8 +80,8 @@ class AccountAccessConsent(val version: OBVersion, val tppResource: CreateTppCal
         return consent to accessToken
     }
 
-    override fun deleteConsent(consentId: String): OBReadConsentResponse1 {
-        return AccountRS().deleteConsent(
+    override fun deleteConsent(consentId: String) {
+        AccountRS().deleteConsent(
             AccountFactory.urlWithConsentId(
                 accountsApiLinks.DeleteAccountAccessConsent,
                 consentId


### PR DESCRIPTION
DELETE account access consent must return HTTP 204 No Content response

https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/537