### PR TITLE
562: Adding file payment consent tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("javax.xml.bind:jaxb-api:2.3.1")
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
-    implementation(platform("com.forgerock.securebanking.uk:securebanking-openbanking-uk-bom:1.1.7-SNAPSHOT"))
+    implementation(platform("com.forgerock.securebanking.uk:securebanking-openbanking-uk-bom:1.1.8-SNAPSHOT"))
     implementation("com.forgerock.securebanking.uk:securebanking-openbanking-uk-common")
     implementation("com.forgerock.securebanking.uk:securebanking-openbanking-uk-obie-datamodel")
     implementation("com.forgerock.securebanking.uk:securebanking-openbanking-uk-forgerock-datamodel")
@@ -103,6 +103,7 @@ dependencies {
     testImplementation("org.apache.httpcomponents:httpclient:4.5.9")
     testImplementation("org.assertj:assertj-core:3.13.2")
     testImplementation("com.nimbusds:nimbus-jose-jwt:9.0.1")
+    testImplementation("commons-io:commons-io:2.6")
 }
 
 /*
@@ -299,6 +300,15 @@ for (apiVersion in apiVersions) {
         failFast = false
     }
 
+    tasks.register<Test>("file_payments_$apiVersion") {
+        group = "payments-tests"
+        description = "Runs the file payments tests with the version $apiVersion"
+        filter {
+            includeTestsMatching(packagePrefix + "payment.file.payments" + suffixPattern + apiVersion)
+        }
+        failFast = false
+    }
+
     /* ALL IMPLEMENTED TESTS */
     tasks.register<Test>("tests_$apiVersion") {
         group = "tests"
@@ -311,6 +321,7 @@ for (apiVersion in apiVersions) {
             includeTestsMatching(packagePrefix + "payment.international.payments" + suffixPattern + apiVersion)
             includeTestsMatching(packagePrefix + "payment.international.scheduled.payments" + suffixPattern + apiVersion)
             includeTestsMatching(packagePrefix + "payment.international.standing.orders" + suffixPattern + apiVersion)
+            includeTestsMatching(packagePrefix + "payment.file.payments" + suffixPattern + apiVersion)
         }
         failFast = false
     }

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/OBJsonPaymentModel.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/OBJsonPaymentModel.kt
@@ -1,9 +1,5 @@
 package com.forgerock.uk.openbanking.support.payment
 
-// To parse the JSON, install jackson-module-kotlin and do:
-//
-//   val welcome = Welcome.fromJson(jsonString)
-
 import com.fasterxml.jackson.annotation.*
 import com.fasterxml.jackson.databind.*
 import com.fasterxml.jackson.module.kotlin.*

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/OBJsonPaymentModel.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/OBJsonPaymentModel.kt
@@ -1,0 +1,103 @@
+package com.forgerock.uk.openbanking.support.payment
+
+// To parse the JSON, install jackson-module-kotlin and do:
+//
+//   val welcome = Welcome.fromJson(jsonString)
+
+import com.fasterxml.jackson.annotation.*
+import com.fasterxml.jackson.databind.*
+import com.fasterxml.jackson.module.kotlin.*
+
+val mapper = jacksonObjectMapper().apply {
+    propertyNamingStrategy = PropertyNamingStrategy.LOWER_CAMEL_CASE
+    setSerializationInclusion(JsonInclude.Include.NON_NULL)
+}
+
+data class JsonFilePayment (
+    @get:JsonProperty("Data", required=true)@field:JsonProperty("Data", required=true)
+    val data: Data
+) {
+    fun toJson() = mapper.writeValueAsString(this)
+
+    companion object {
+        fun fromJson(json: String) = mapper.readValue<JsonFilePayment>(json)
+    }
+}
+
+data class Data (
+    @get:JsonProperty("DomesticPayments", required=true)@field:JsonProperty("DomesticPayments", required=true)
+    val domesticPayments: List<DomesticPayment>
+)
+
+data class DomesticPayment (
+    @get:JsonProperty("InstructionIdentification", required=true)@field:JsonProperty("InstructionIdentification", required=true)
+    val instructionIdentification: String,
+
+    @get:JsonProperty("EndToEndIdentification", required=true)@field:JsonProperty("EndToEndIdentification", required=true)
+    val endToEndIdentification: String,
+
+    @get:JsonProperty("LocalInstrument")@field:JsonProperty("LocalInstrument")
+    val localInstrument: String? = null,
+
+    @get:JsonProperty("InstructedAmount", required=true)@field:JsonProperty("InstructedAmount", required=true)
+    val instructedAmount: InstructedAmount,
+
+    @get:JsonProperty("DebtorAccount", required=true)@field:JsonProperty("DebtorAccount", required=true)
+    val debtorAccount: DebtorAccount,
+
+    @get:JsonProperty("CreditorAccount", required=true)@field:JsonProperty("CreditorAccount", required=true)
+    val creditorAccount: DebtorAccount,
+
+    @get:JsonProperty("CreditorPostalAddress")@field:JsonProperty("CreditorPostalAddress")
+    val creditorPostalAddress: CreditorPostalAddress? = null,
+
+    @get:JsonProperty("RemittanceInformation", required=true)@field:JsonProperty("RemittanceInformation", required=true)
+    val remittanceInformation: RemittanceInformation
+)
+
+data class DebtorAccount (
+    @get:JsonProperty("SchemeName", required=true)@field:JsonProperty("SchemeName", required=true)
+    val schemeName: String,
+
+    @get:JsonProperty("Identification", required=true)@field:JsonProperty("Identification", required=true)
+    val identification: String,
+
+    @get:JsonProperty("Name", required=true)@field:JsonProperty("Name", required=true)
+    val name: String
+)
+
+data class CreditorPostalAddress (
+    @get:JsonProperty("AddressType", required=true)@field:JsonProperty("AddressType", required=true)
+    val addressType: String,
+
+    @get:JsonProperty("StreetName", required=true)@field:JsonProperty("StreetName", required=true)
+    val streetName: String,
+
+    @get:JsonProperty("BuildingNumber", required=true)@field:JsonProperty("BuildingNumber", required=true)
+    val buildingNumber: String,
+
+    @get:JsonProperty("PostCode", required=true)@field:JsonProperty("PostCode", required=true)
+    val postCode: String,
+
+    @get:JsonProperty("TownName", required=true)@field:JsonProperty("TownName", required=true)
+    val townName: String,
+
+    @get:JsonProperty("Country", required=true)@field:JsonProperty("Country", required=true)
+    val country: String
+)
+
+data class InstructedAmount (
+    @get:JsonProperty("Amount", required=true)@field:JsonProperty("Amount", required=true)
+    val amount: String,
+
+    @get:JsonProperty("Currency", required=true)@field:JsonProperty("Currency", required=true)
+    val currency: String
+)
+
+data class RemittanceInformation (
+    @get:JsonProperty("Reference", required=true)@field:JsonProperty("Reference", required=true)
+    val reference: String,
+
+    @get:JsonProperty("Unstructured", required=true)@field:JsonProperty("Unstructured", required=true)
+    val unstructured: String
+)

--- a/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentFactory.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/support/payment/PaymentFactory.kt
@@ -20,6 +20,12 @@ import javax.xml.bind.JAXB
  * Generate common OB payment URLs
  */
 class PaymentFactory {
+
+    object FilePaths {
+        const val XML_FILE_PATH = "/com/forgerock/securebanking/payment/file/UK_OBIE_pain_001_001_08.xml"
+        const val JSON_FILE_PATH = "/com/forgerock/securebanking/payment/file/UK_OBIE_PaymentInitiation_3_1.json"
+    }
+
     companion object {
         fun urlWithConsentId(url: String, consentId: String) =
             urlSubstituted(url, mapOf("ConsentId" to consentId))
@@ -59,20 +65,7 @@ class PaymentFactory {
             }
         }
 
-        fun getXMLFileAsString(): String {
-            val filePath = "/com/forgerock/securebanking/payment/file/UK_OBIE_pain_001_001_08.xml"
-            try {
-                return FileUtils.readFileToString(
-                    File(object {}.javaClass.getResource(filePath)?.file.toString()),
-                    StandardCharsets.UTF_8
-                )
-            } catch (e: NullPointerException) {
-                throw AssertionError("Could not load file: $filePath")
-            }
-        }
-
-        fun getJSONFileAsString(): String {
-            val filePath = "/com/forgerock/securebanking/payment/file/UK_OBIE_PaymentInitiation_3_1.json"
+        fun getFileAsString(filePath: String): String {
             try {
                 return FileUtils.readFileToString(
                     File(object {}.javaClass.getResource(filePath)?.file.toString()),

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/api/v3_1_8/CreateFilePaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/api/v3_1_8/CreateFilePaymentsConsents.kt
@@ -1,0 +1,281 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.api.v3_1_8
+
+import assertk.assertThat
+import assertk.assertions.*
+import com.forgerock.securebanking.framework.conditions.Status
+import com.forgerock.securebanking.framework.configuration.psu
+import com.forgerock.securebanking.framework.data.AccessToken
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.framework.errors.*
+import com.forgerock.uk.openbanking.support.discovery.getPaymentsApiLinks
+import com.forgerock.uk.openbanking.support.payment.*
+import com.github.kittinunf.fuel.core.FuelError
+import org.assertj.core.api.Assertions
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4
+import java.math.BigDecimal
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Size
+
+class CreateFilePaymentsConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
+
+    private val paymentLinks = getPaymentsApiLinks(version)
+    private val paymentApiClient = tppResource.tpp.paymentApiClient
+
+    fun createFilePaymentsConsentsTest() {
+        // Given
+        val fileContent = PaymentFactory.getXMLFileAsString()
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+        val consent = createFilePaymentConsent(consentRequest)
+
+        // Then
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+    }
+
+    fun submitXMLFileTest() {
+        // Given
+        val fileContent = PaymentFactory.getXMLFileAsString()
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+
+        // when
+        val consent = sendSubmitFileRequest(consentRequest, fileContent)
+
+        // Then
+        assertThat(consent).isNotNull()
+        assertThat(consent).isTrue()
+    }
+
+    fun submitJSONFileTest() {
+        // Given
+        val fileContent = PaymentFactory.getJSONFileAsString()
+        val fileJson = JsonFilePayment.fromJson(fileContent)
+
+        val controlSum = fileJson.data.domesticPayments.stream().map(DomesticPayment::instructedAmount)
+            .map(InstructedAmount::amount)
+            .map(String::toBigDecimal)
+            .reduce(BigDecimal.ZERO, BigDecimal::add).toPlainString()
+
+        val numberOfPayments = fileJson.data.domesticPayments.size
+        val fileHash = PaymentFactory.computeSHA256FullHash(fileContent)
+
+        val consentRequest = PaymentFactory.createJsonOBWriteFileConsent3WithFileInfo(
+            fileHash,
+            controlSum,
+            numberOfPayments.toString(),
+            PaymentFileType.UK_OBIE_PAYMENT_INITIATION_V3_1.type
+        )
+
+        // when
+        val consent = sendSubmitJsonFileRequest(consentRequest, fileContent)
+
+        // Then
+        assertThat(consent).isNotNull()
+        assertThat(consent).isTrue()
+    }
+
+    fun createFilePaymentsConsents_mandatoryFields() {
+        // Given
+        val fileContent = PaymentFactory.getXMLFileAsString()
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithMandatoryFieldsAndFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+
+        // when
+        val consent = createFilePaymentConsent(consentRequest)
+
+        // Then
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+    }
+
+    fun shouldCreateFilePaymentsConsents_throwsSendInvalidFormatDetachedJwsTest() {
+        // Given
+        val fileContent = PaymentFactory.getXMLFileAsString()
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+
+        // When
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            buildCreateConsentRequest(consentRequest).configureJwsSignatureProducer(BadJwsSignatureProducer())
+                .sendRequest()
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(INVALID_FORMAT_DETACHED_JWS_ERROR)
+    }
+
+    fun shouldCreateFilePaymentsConsents_throwsNoDetachedJwsTest() {
+        // Given
+        val fileContent = PaymentFactory.getXMLFileAsString()
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+
+        // When
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            buildCreateConsentRequest(consentRequest).configureJwsSignatureProducer(null).sendRequest()
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(400)
+        assertThat(exception.message.toString()).contains(NO_DETACHED_JWS)
+    }
+
+    fun shouldCreateFilePaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest() {
+        // Given
+        val fileContent = PaymentFactory.getXMLFileAsString()
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+
+        // When
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            buildCreateConsentRequest(consentRequest).configureJwsSignatureProducer(
+                DefaultJwsSignatureProducer(
+                    tppResource.tpp,
+                    false
+                )
+            ).sendRequest()
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
+    }
+
+    fun shouldCreateFilePaymentsConsents_throwsSendInvalidKidDetachedJwsTest() {
+        // Given
+        val fileContent = PaymentFactory.getXMLFileAsString()
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+
+        // When
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            buildCreateConsentRequest(consentRequest).configureJwsSignatureProducer(
+                InvalidKidJwsSignatureProducer(
+                    tppResource.tpp
+                )
+            ).sendRequest()
+        }
+
+        // Then
+        assertThat((exception.cause as FuelError).response.statusCode).isEqualTo(401)
+        assertThat((exception.cause as FuelError).response.responseMessage).isEqualTo(UNAUTHORIZED)
+    }
+
+    fun shouldCreateFilePaymentsConsents_throwsRejectedConsentTest() {
+        // Given
+        val fileContent = PaymentFactory.getXMLFileAsString()
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+
+        // When
+        val exception = org.junit.jupiter.api.Assertions.assertThrows(AssertionError::class.java) {
+            createFilePaymentConsentAndReject(
+                consentRequest
+            )
+        }
+
+        // Then
+        assertThat(exception.message.toString()).contains(CONSENT_NOT_AUTHORISED)
+    }
+
+    fun createFilePaymentConsent(consentRequest: OBWriteFileConsent3): OBWriteFileConsentResponse4 {
+        return buildCreateConsentRequest(consentRequest).sendRequest()
+    }
+
+    private fun buildCreateConsentRequest(
+        consent: OBWriteFileConsent3
+    ) = paymentApiClient.newPostRequestBuilder(
+        paymentLinks.CreateFilePaymentConsent,
+        tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken),
+        consent
+    )
+
+    private fun sendSubmitFileRequest(consentRequest: OBWriteFileConsent3, fileContent: String): Boolean {
+        val consent = createFilePaymentConsent(consentRequest)
+        return buildSubmitFileRequest(fileContent, consent.data.consentId).sendFileRequest()
+    }
+
+    private fun buildSubmitFileRequest(
+        consent: String,
+        consentId: @NotNull @Size(max = 128, min = 1) String
+    ) = paymentApiClient.newFilePostRequestBuilder(
+        PaymentFactory.urlWithFilePaymentSubmitFileId(paymentLinks.CreateFilePaymentFile, consentId),
+        tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken),
+        consent
+    )
+
+    private fun sendSubmitJsonFileRequest(consentRequest: OBWriteFileConsent3, fileContent: String): Boolean {
+        val consent = createFilePaymentConsent(consentRequest)
+        return buildSubmitJsonFileRequest(fileContent, consent.data.consentId).sendJsonFileRequest()
+    }
+
+    private fun buildSubmitJsonFileRequest(
+        consent: String,
+        consentId: @NotNull @Size(max = 128, min = 1) String
+    ) = paymentApiClient.newJsonFilePostRequestBuilder(
+        PaymentFactory.urlWithFilePaymentSubmitFileId(paymentLinks.CreateFilePaymentFile, consentId),
+        tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken),
+        consent
+    )
+
+    fun createFilePaymentConsentAndAuthorize(consentRequest: OBWriteFileConsent3): Pair<OBWriteFileConsentResponse4, AccessToken> {
+        val consent = createFilePaymentConsent(consentRequest)
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
+            consent.data.consentId,
+            tppResource.tpp.registrationResponse,
+            psu,
+            tppResource.tpp
+        )
+        return consent to accessTokenAuthorizationCode
+    }
+
+    private fun createFilePaymentConsentAndReject(consentRequest: OBWriteFileConsent3): Pair<OBWriteFileConsentResponse4, AccessToken> {
+        val consent = createFilePaymentConsent(consentRequest)
+        val accessTokenAuthorizationCode = PaymentAS().authorizeConsent(
+            consent.data.consentId,
+            tppResource.tpp.registrationResponse,
+            psu,
+            tppResource.tpp,
+            "Rejected"
+        )
+        return consent to accessTokenAuthorizationCode
+    }
+
+    fun getPatchedConsent(consent: OBWriteFileConsentResponse4): OBWriteFileConsentResponse4 {
+        val patchedConsent = paymentApiClient.getConsent<OBWriteFileConsentResponse4>(
+            paymentLinks.GetFilePaymentConsent,
+            consent.data.consentId,
+            tppResource.tpp.getClientCredentialsAccessToken(defaultPaymentScopesForAccessToken)
+        )
+        assertThat(patchedConsent).isNotNull()
+        assertThat(patchedConsent.data).isNotNull()
+        assertThat(patchedConsent.data.consentId).isNotEmpty()
+        Assertions.assertThat(patchedConsent.data.status.toString()).`is`(Status.consentCondition)
+        return patchedConsent
+    }
+
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/api/v3_1_8/GetFilePaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/api/v3_1_8/GetFilePaymentsConsents.kt
@@ -18,7 +18,7 @@ class GetFilePaymentsConsents(val version: OBVersion, val tppResource: CreateTpp
 
     fun shouldGetFilePaymentsConsents() {
         // Given
-        val fileContent = PaymentFactory.getXMLFileAsString()
+        val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
         val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
             fileContent,
             PaymentFileType.UK_OBIE_PAIN_001_001_008.type
@@ -44,7 +44,7 @@ class GetFilePaymentsConsents(val version: OBVersion, val tppResource: CreateTpp
 
     fun shouldGetFilePaymentsConsents_withoutOptionalDebtorAccountTest() {
         // Given
-        val fileContent = PaymentFactory.getXMLFileAsString()
+        val fileContent = PaymentFactory.getFileAsString(PaymentFactory.FilePaths.XML_FILE_PATH)
         val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
             fileContent,
             PaymentFileType.UK_OBIE_PAIN_001_001_008.type

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/api/v3_1_8/GetFilePaymentsConsents.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/api/v3_1_8/GetFilePaymentsConsents.kt
@@ -1,0 +1,72 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.api.v3_1_8
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEmpty
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import com.forgerock.securebanking.framework.conditions.Status
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.support.payment.PaymentFactory
+import com.forgerock.uk.openbanking.support.payment.PaymentFileType
+import org.assertj.core.api.Assertions
+
+class GetFilePaymentsConsents(val version: OBVersion, val tppResource: CreateTppCallback.TppResource) {
+
+    private val createFilePaymentsConsentsApi = CreateFilePaymentsConsents(version, tppResource)
+
+    fun shouldGetFilePaymentsConsents() {
+        // Given
+        val fileContent = PaymentFactory.getXMLFileAsString()
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+        val consent = createFilePaymentsConsentsApi.createFilePaymentConsent(consentRequest)
+
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+
+        // When
+        val result = createFilePaymentsConsentsApi.getPatchedConsent(consent)
+
+        // Then
+        assertThat(result).isNotNull()
+        assertThat(result.data).isNotNull()
+        assertThat(result.data).isEqualTo(consent.data)
+        assertThat(result.data.initiation.fileHash).isEqualTo(consent.data.initiation.fileHash)
+        assertThat(result.data.initiation.fileReference).isEqualTo(consent.data.initiation.fileReference)
+        assertThat(result.data.initiation.fileType).isEqualTo(consent.data.initiation.fileType)
+    }
+
+    fun shouldGetFilePaymentsConsents_withoutOptionalDebtorAccountTest() {
+        // Given
+        val fileContent = PaymentFactory.getXMLFileAsString()
+        val consentRequest = PaymentFactory.createOBWriteFileConsent3WithFileInfo(
+            fileContent,
+            PaymentFileType.UK_OBIE_PAIN_001_001_008.type
+        )
+        consentRequest.data.initiation.debtorAccount(null)
+
+        val consent = createFilePaymentsConsentsApi.createFilePaymentConsent(consentRequest)
+
+        assertThat(consent).isNotNull()
+        assertThat(consent.data).isNotNull()
+        assertThat(consent.data.consentId).isNotEmpty()
+        Assertions.assertThat(consent.data.status.toString()).`is`(Status.consentCondition)
+        assertThat(consent.data.initiation.debtorAccount).isNull()
+
+        // When
+        val result = createFilePaymentsConsentsApi.getPatchedConsent(consent)
+
+        // Then
+        assertThat(result).isNotNull()
+        assertThat(result.data).isNotNull()
+        assertThat(result.data).isEqualTo(consent.data)
+        assertThat(result.data.initiation.debtorAccount).isNull()
+    }
+
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_10/CreateFilePaymentConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_10/CreateFilePaymentConsentsTest.kt
@@ -1,0 +1,118 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.api.v3_1_8.CreateFilePaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateFilePaymentConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    private lateinit var createFilePaymentsConsentsApi: CreateFilePaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        createFilePaymentsConsentsApi = CreateFilePaymentsConsents(OBVersion.v3_1_10, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun submitXMLFile_v3_1_10() {
+        createFilePaymentsConsentsApi.submitXMLFileTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun submitJSONFile_v3_1_10() {
+        createFilePaymentsConsentsApi.submitJSONFileTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun createFilePaymentsConsents_v3_1_10() {
+        createFilePaymentsConsentsApi.createFilePaymentsConsentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun createFilePaymentsConsentsMandatoryFields_v3_1_10() {
+        createFilePaymentsConsentsApi.createFilePaymentsConsents_mandatoryFields()
+    }
+
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePaymentsConsents_throwsNoDetachedJws_v3_1_10() {
+        createFilePaymentsConsentsApi.shouldCreateFilePaymentsConsents_throwsNoDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_10() {
+        createFilePaymentsConsentsApi.shouldCreateFilePaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePaymentsConsents_throwsSendInvalidFormatDetachedJws_v3_1_10() {
+        createFilePaymentsConsentsApi.shouldCreateFilePaymentsConsents_throwsSendInvalidFormatDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePaymentsConsents_throwsSendInvalidKidDetachedJws_v3_1_10() {
+        createFilePaymentsConsentsApi.shouldCreateFilePaymentsConsents_throwsSendInvalidKidDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.10",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePaymentsConsents_throwsRejectedConsent_v3_1_10() {
+        createFilePaymentsConsentsApi.shouldCreateFilePaymentsConsents_throwsRejectedConsentTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_10/GetFilePaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_10/GetFilePaymentsConsentsTest.kt
@@ -1,0 +1,42 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.junit.v3_1_10
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.api.v3_1_8.GetFilePaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetFilePaymentsConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    private lateinit var getFilePaymentsConsentsApi: GetFilePaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        getFilePaymentsConsentsApi = GetFilePaymentsConsents(OBVersion.v3_1_8, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetFilePaymentsConsents_v3_1_8() {
+        getFilePaymentsConsentsApi.shouldGetFilePaymentsConsents()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetFilePaymentsConsents_withoutOptionalDebtorAccount_v3_1_8() {
+        getFilePaymentsConsentsApi.shouldGetFilePaymentsConsents_withoutOptionalDebtorAccountTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_8/CreateFilePaymentConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_8/CreateFilePaymentConsentsTest.kt
@@ -1,0 +1,127 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.junit.v3_1_8
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.api.v3_1_8.CreateFilePaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateFilePaymentConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    private lateinit var createFilePaymentsConsentsApi: CreateFilePaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        createFilePaymentsConsentsApi = CreateFilePaymentsConsents(OBVersion.v3_1_8, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun submitXMLFile_v3_1_8() {
+        createFilePaymentsConsentsApi.submitXMLFileTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun submitJSONFile_v3_1_8() {
+        createFilePaymentsConsentsApi.submitJSONFileTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createFilePaymentsConsents_v3_1_8() {
+        createFilePaymentsConsentsApi.createFilePaymentsConsentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun createFilePaymentsConsentsMandatoryFields_v3_1_8() {
+        createFilePaymentsConsentsApi.createFilePaymentsConsents_mandatoryFields()
+    }
+
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateFilePaymentsConsents_throwsNoDetachedJws_v3_1_8() {
+        createFilePaymentsConsentsApi.shouldCreateFilePaymentsConsents_throwsNoDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateFilePaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_8() {
+        createFilePaymentsConsentsApi.shouldCreateFilePaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateFilePaymentsConsents_throwsSendInvalidFormatDetachedJws_v3_1_8() {
+        createFilePaymentsConsentsApi.shouldCreateFilePaymentsConsents_throwsSendInvalidFormatDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateFilePaymentsConsents_throwsSendInvalidKidDetachedJws_v3_1_8() {
+        createFilePaymentsConsentsApi.shouldCreateFilePaymentsConsents_throwsSendInvalidKidDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldCreateFilePaymentsConsents_throwsRejectedConsent_v3_1_8() {
+        createFilePaymentsConsentsApi.shouldCreateFilePaymentsConsents_throwsRejectedConsentTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_8/GetFilePaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_8/GetFilePaymentsConsentsTest.kt
@@ -1,0 +1,42 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.junit.v3_1_8
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.api.v3_1_8.GetFilePaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetFilePaymentsConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    lateinit var getFilePaymentsConsentsApi: GetFilePaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        getFilePaymentsConsentsApi = GetFilePaymentsConsents(OBVersion.v3_1_8, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetFilePaymentsConsents_v3_1_8() {
+        getFilePaymentsConsentsApi.shouldGetFilePaymentsConsents()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetFilePaymentsConsents_withoutOptionalDebtorAccount_v3_1_8() {
+        getFilePaymentsConsentsApi.shouldGetFilePaymentsConsents_withoutOptionalDebtorAccountTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_9/CreateFilePaymentConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_9/CreateFilePaymentConsentsTest.kt
@@ -1,0 +1,118 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.api.v3_1_8.CreateFilePaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateFilePaymentConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    private lateinit var createFilePaymentsConsentsApi: CreateFilePaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        createFilePaymentsConsentsApi = CreateFilePaymentsConsents(OBVersion.v3_1_9, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun submitXMLFile_v3_1_9() {
+        createFilePaymentsConsentsApi.submitXMLFileTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun submitJSONFile_v3_1_9() {
+        createFilePaymentsConsentsApi.submitJSONFileTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun createFilePaymentsConsents_v3_1_9() {
+        createFilePaymentsConsentsApi.createFilePaymentsConsentsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun createFilePaymentsConsentsMandatoryFields_v3_1_9() {
+        createFilePaymentsConsentsApi.createFilePaymentsConsents_mandatoryFields()
+    }
+
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePaymentsConsents_throwsNoDetachedJws_v3_1_9() {
+        createFilePaymentsConsentsApi.shouldCreateFilePaymentsConsents_throwsNoDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJws_v3_1_9() {
+        createFilePaymentsConsentsApi.shouldCreateFilePaymentsConsents_throwsNotPermittedB64HeaderAddedInTheDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePaymentsConsents_throwsSendInvalidFormatDetachedJws_v3_1_9() {
+        createFilePaymentsConsentsApi.shouldCreateFilePaymentsConsents_throwsSendInvalidFormatDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePaymentsConsents_throwsSendInvalidKidDetachedJws_v3_1_9() {
+        createFilePaymentsConsentsApi.shouldCreateFilePaymentsConsents_throwsSendInvalidKidDetachedJwsTest()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.9",
+        operations = ["CreateFilePaymentConsent"],
+        apis = ["file-payment-consents"]
+    )
+    @Test
+    fun shouldCreateFilePaymentsConsents_throwsRejectedConsent_v3_1_9() {
+        createFilePaymentsConsentsApi.shouldCreateFilePaymentsConsents_throwsRejectedConsentTest()
+    }
+}

--- a/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_9/GetFilePaymentsConsentsTest.kt
+++ b/src/test/kotlin/com/forgerock/uk/openbanking/tests/functional/payment/file/payments/consents/junit/v3_1_9/GetFilePaymentsConsentsTest.kt
@@ -1,0 +1,42 @@
+package com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.junit.v3_1_9
+
+import com.forgerock.securebanking.framework.extensions.junit.CreateTppCallback
+import com.forgerock.securebanking.framework.extensions.junit.EnabledIfVersion
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
+import com.forgerock.uk.openbanking.tests.functional.payment.file.payments.consents.api.v3_1_8.GetFilePaymentsConsents
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetFilePaymentsConsentsTest(val tppResource: CreateTppCallback.TppResource) {
+
+    private lateinit var getFilePaymentsConsentsApi: GetFilePaymentsConsents
+
+    @BeforeEach
+    fun setUp() {
+        getFilePaymentsConsentsApi = GetFilePaymentsConsents(OBVersion.v3_1_8, tppResource)
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetFilePaymentsConsents_v3_1_8() {
+        getFilePaymentsConsentsApi.shouldGetFilePaymentsConsents()
+    }
+
+    @EnabledIfVersion(
+        type = "payments",
+        apiVersion = "v3.1.8",
+        operations = ["CreateFilePaymentConsent", "GetFilePaymentConsent"],
+        apis = ["file-payment-consents"],
+        compatibleVersions = ["v.3.1.7", "v.3.1.6", "v.3.1.5"]
+    )
+    @Test
+    fun shouldGetFilePaymentsConsents_withoutOptionalDebtorAccount_v3_1_8() {
+        getFilePaymentsConsentsApi.shouldGetFilePaymentsConsents_withoutOptionalDebtorAccountTest()
+    }
+}

--- a/src/test/resources/com/forgerock/securebanking/payment/file/UK_OBIE_PaymentInitiation_3_1.json
+++ b/src/test/resources/com/forgerock/securebanking/payment/file/UK_OBIE_PaymentInitiation_3_1.json
@@ -1,0 +1,113 @@
+{
+  "Data": {
+    "DomesticPayments": [
+      {
+        "InstructionIdentification": "ANSM020",
+        "EndToEndIdentification": "FRESCO.21302.GFX.01",
+        "LocalInstrument": "UK.OBIE.CHAPS",
+        "InstructedAmount": {
+          "Amount": "21.00",
+          "Currency": "GBP"
+        },
+        "DebtorAccount": {
+          "SchemeName": "UK.OBIE.SortCodeAccountNumber",
+          "Identification": "11280001234567",
+          "Name": "Andrea Smith"
+        },
+        "CreditorAccount": {
+          "SchemeName": "UK.OBIE.SortCodeAccountNumber",
+          "Identification": "08080021325698",
+          "Name": "Bob Clements"
+        },
+        "CreditorPostalAddress": {
+          "AddressType": "Correspondence",
+          "StreetName": "Liberty",
+          "BuildingNumber": "1",
+          "PostCode": "AB1 2CD",
+          "TownName": "London",
+          "Country": "UK"
+        },
+        "RemittanceInformation": {
+          "Reference": "FRESCO-037",
+          "Unstructured": "Internal ops code 5120103"
+        }
+      },
+      {
+        "InstructionIdentification": "ANSM020",
+        "EndToEndIdentification": "FRESCO.21302.GFX.01",
+        "LocalInstrument": "UK.OBIE.CHAPS",
+        "InstructedAmount": {
+          "Amount": "21.00",
+          "Currency": "GBP"
+        },
+        "DebtorAccount": {
+          "SchemeName": "UK.OBIE.SortCodeAccountNumber",
+          "Identification": "11280001234567",
+          "Name": "Andrea Smith"
+        },
+        "CreditorAccount": {
+          "SchemeName": "UK.OBIE.SortCodeAccountNumber",
+          "Identification": "08080021325698",
+          "Name": "Bob Clements"
+        },
+        "CreditorPostalAddress": {
+          "AddressType": "Correspondence",
+          "StreetName": "Liberty",
+          "BuildingNumber": "1",
+          "PostCode": "AB1 2CD",
+          "TownName": "London",
+          "Country": "UK"
+        },
+        "RemittanceInformation": {
+          "Reference": "FRESCO-037",
+          "Unstructured": "Internal ops code 5120103"
+        }
+      },
+      {
+        "InstructionIdentification": "ANSM021",
+        "EndToEndIdentification": "FRESCO.21302.GFX.02",
+        "LocalInstrument": "UK.OBIE.BACS",
+        "InstructedAmount": {
+          "Amount": "22.00",
+          "Currency": "GBP"
+        },
+        "DebtorAccount": {
+          "SchemeName": "UK.OBIE.SortCodeAccountNumber",
+          "Identification": "11280001234567",
+          "Name": "Andrea Smith"
+        },
+        "CreditorAccount": {
+          "SchemeName": "UK.OBIE.SortCodeAccountNumber",
+          "Identification": "08080021325698",
+          "Name": "Bob Clements"
+        },
+        "RemittanceInformation": {
+          "Reference": "FRESCO-037",
+          "Unstructured": "Internal ops code 5120103"
+        }
+      },
+      {
+        "InstructionIdentification": "ANSM022",
+        "EndToEndIdentification": "FRESCO.21302.GFX.03",
+        "InstructedAmount": {
+          "Amount": "23.00",
+          "Currency": "GBP"
+        },
+        "DebtorAccount": {
+          "SchemeName": "UK.OBIE.SortCodeAccountNumber",
+          "Identification": "11280001234567",
+          "Name": "Andrea Smith"
+        },
+        "CreditorAccount": {
+          "SchemeName": "UK.OBIE.SortCodeAccountNumber",
+          "Identification": "08080021325698",
+          "Name": "Bob Clements"
+        },
+        "RemittanceInformation": {
+          "Reference": "FRESCO-037",
+          "Unstructured": "Internal ops code 5120103"
+        }
+      }
+    ]
+  }
+}

--- a/src/test/resources/com/forgerock/securebanking/payment/file/UK_OBIE_pain_001_001_08.xml
+++ b/src/test/resources/com/forgerock/securebanking/payment/file/UK_OBIE_pain_001_001_08.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.001.001.08" xmlns:xsi="http://www.w3.org/2001/XMLSchema- instance">
+    <CstmrCdtTrfInitn>
+        <GrpHdr>
+            <MsgId>ABC/120928/CCT001</MsgId>
+            <CreDtTm>2012-09-28T14:07:00</CreDtTm>
+            <NbOfTxs>3</NbOfTxs>
+            <CtrlSum>11500000</CtrlSum>
+            <InitgPty>
+                <Nm>ABC Corporation</Nm>
+                <PstlAdr>
+                    <StrtNm>Times Square</StrtNm>
+                    <BldgNb>7</BldgNb>
+                    <PstCd>NY 10036</PstCd>
+                    <TwnNm>New York</TwnNm>
+                    <Ctry>US</Ctry>
+                </PstlAdr>
+            </InitgPty>
+        </GrpHdr>
+        <PmtInf>
+            <PmtInfId>ABC/086</PmtInfId>
+            <PmtMtd>TRF</PmtMtd>
+            <BtchBookg>false</BtchBookg>
+            <ReqdExctnDt>
+                <Dt>2012-09-29</Dt>
+            </ReqdExctnDt>
+            <Dbtr>
+                <Nm>ABC Corporation</Nm>
+                <PstlAdr>
+                    <StrtNm>Times Square</StrtNm>
+                    <BldgNb>7</BldgNb>
+                    <PstCd>NY 10036</PstCd>
+                    <TwnNm>New York</TwnNm>
+                    <Ctry>US</Ctry>
+                </PstlAdr>
+            </Dbtr>
+            <DbtrAcct>
+                <Id>
+                    <Othr>
+                        <Id>00125574999</Id>
+                    </Othr>
+                </Id>
+            </DbtrAcct>
+            <DbtrAgt>
+                <FinInstnId>
+                    <BICFI>BBBBUS33</BICFI>
+                </FinInstnId>
+            </DbtrAgt>
+            <CdtTrfTxInf>
+                <PmtId>
+                    <InstrId>ABC/120928/CCT001/01</InstrId>
+                    <EndToEndId>ABC/4562/2012-09-08</EndToEndId>
+                </PmtId>
+                <Amt>
+                    <InstdAmt Ccy="JPY">10000000</InstdAmt>
+                </Amt>
+                <ChrgBr>SHAR</ChrgBr>
+                <CdtrAgt>
+                    <FinInstnId>
+                        <BICFI>AAAAGB2L</BICFI>
+                    </FinInstnId>
+                </CdtrAgt>
+                <Cdtr>
+                    <Nm>DEF Electronics</Nm>
+                    <PstlAdr>
+                        <AdrLine>Corn Exchange 5th Floor</AdrLine>
+                        <AdrLine>Mark Lane 55</AdrLine>
+                        <AdrLine>EC3R7NE London</AdrLine>
+                        <AdrLine>GB</AdrLine>
+                    </PstlAdr>
+                </Cdtr>
+                <CdtrAcct>
+                    <Id>
+                        <Othr>
+                            <Id>23683707994125</Id>
+                        </Othr>
+                    </Id>
+                </CdtrAcct>
+                <Purp>
+                    <Cd>GDDS</Cd>
+                </Purp>
+                <RmtInf>
+                    <Strd>
+                        <RfrdDocInf>
+                            <Tp>
+                                <CdOrPrtry>
+                                    <Cd>CINV</Cd>
+                                </CdOrPrtry>
+                            </Tp>
+                            <Nb>4562</Nb>
+                            <RltdDt>2012-09-08</RltdDt>
+                        </RfrdDocInf>
+                    </Strd>
+                </RmtInf>
+            </CdtTrfTxInf>
+            <CdtTrfTxInf>
+                <PmtId>
+                    <InstrId>ABC/120928/CCT001/2</InstrId>
+                    <EndToEndId>ABC/ABC-13679/2012-09-15</EndToEndId>
+                </PmtId>
+                <Amt>
+                    <InstdAmt Ccy="EUR">500000</InstdAmt>
+                </Amt>
+                <ChrgBr>CRED</ChrgBr>
+                <CdtrAgt>
+                    <FinInstnId>
+                        <BICFI>DDDDBEBB</BICFI>
+                    </FinInstnId>
+                </CdtrAgt>
+                <Cdtr>
+                    <Nm>GHI Semiconductors</Nm>
+                    <PstlAdr>
+                        <StrtNm>Avenue Brugmann</StrtNm>
+                        <BldgNb>415</BldgNb>
+                        <PstCd>1180</PstCd>
+                        <TwnNm>Brussels</TwnNm>
+                        <Ctry>BE</Ctry>
+                    </PstlAdr>
+                </Cdtr>
+                <CdtrAcct>
+                    <Id>
+                        <IBAN>BE30001216371411</IBAN>
+                    </Id>
+                </CdtrAcct>
+                <InstrForCdtrAgt>
+                    <Cd>PHOB</Cd>
+                    <InstrInf>+32/2/2222222</InstrInf>
+                </InstrForCdtrAgt>
+                <Purp>
+                    <Cd>GDDS</Cd>
+                </Purp>
+                <RmtInf>
+                    <Strd>
+                        <RfrdDocInf>
+                            <Tp>
+                                <CdOrPrtry>
+                                    <Cd>CINV</Cd>
+                                </CdOrPrtry>
+                            </Tp>
+                            <Nb>ABC-13679</Nb>
+                            <RltdDt>2012-09-15</RltdDt>
+                        </RfrdDocInf>
+                    </Strd>
+                </RmtInf>
+            </CdtTrfTxInf>
+            <CdtTrfTxInf>
+                <PmtId>
+                    <InstrId>ABC/120928/CCT001/3</InstrId>
+                    <EndToEndId>ABC/987-AC/2012-09-27</EndToEndId>
+                </PmtId>
+                <Amt>
+                    <InstdAmt Ccy="USD">1000000</InstdAmt>
+                </Amt>
+                <ChrgBr>SHAR</ChrgBr>
+                <CdtrAgt>
+                    <FinInstnId>
+                        <BICFI>BBBBUS66</BICFI>
+                    </FinInstnId>
+                </CdtrAgt>
+                <Cdtr>
+                    <Nm>ABC Corporation</Nm>
+                    <PstlAdr>
+                        <Dept>Treasury department</Dept>
+                        <StrtNm>Bush Street</StrtNm>
+                        <BldgNb>13</BldgNb>
+                        <PstCd>CA 94108</PstCd>
+                        <TwnNm>San Francisco</TwnNm>
+                        <Ctry>US</Ctry>
+                    </PstlAdr>
+                </Cdtr>
+                <CdtrAcct>
+                    <Id>
+                        <Othr>
+                            <Id>4895623</Id>
+                        </Othr>
+                    </Id>
+                </CdtrAcct>
+                <Purp>
+                    <Cd>INTC</Cd>
+                </Purp>
+                <RmtInf>
+                    <Strd>
+                        <RfrdDocInf>
+                            <Tp>
+                                <CdOrPrtry>
+                                    <Cd>CINV</Cd>
+                                </CdOrPrtry>
+                            </Tp>
+                            <Nb>987-AC</Nb>
+                            <RltdDt>2012-09-27</RltdDt>
+                        </RfrdDocInf>
+                    </Strd>
+                </RmtInf>
+            </CdtTrfTxInf>
+        </PmtInf>
+    </CstmrCdtTrfInitn>
+</Document>


### PR DESCRIPTION
Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/562
Description: Added file payment consents functional tests including the ones for the new SubmitFile API (supporting both XML & JSON content-types).